### PR TITLE
[FEAT]: Add intructions to increment 8 bits registers

### DIFF
--- a/cpus/intel_8080.py
+++ b/cpus/intel_8080.py
@@ -30,17 +30,22 @@ class Intel8080(CPU):
         self.registers[Registers.L] = 0x00
 
         self.add_instruction(0x03, self.increment_bc_register)
-        self.add_instruction(0x04, self.increment_b_register)
+        self.add_instruction(0x04, lambda: self.increment_register(Registers.B))
         self.add_instruction(0x06, self.move_immediate_to_register(Registers.B))
+        self.add_instruction(0x0C, lambda: self.increment_register(Registers.C))
         self.add_instruction(0x0E, self.move_immediate_to_register(Registers.C))
+        self.add_instruction(0x14, lambda: self.increment_register(Registers.D))
         self.add_instruction(0x16, self.move_immediate_to_register(Registers.D))
+        self.add_instruction(0x1C, lambda: self.increment_register(Registers.E))
         self.add_instruction(0x1E, self.move_immediate_to_register(Registers.E))
+        self.add_instruction(0x24, lambda: self.increment_register(Registers.H))
         self.add_instruction(0x26, self.move_immediate_to_register(Registers.H))
+        self.add_instruction(0x2C, lambda: self.increment_register(Registers.L))
         self.add_instruction(0x2E, self.move_immediate_to_register(Registers.L))
         self.add_instruction(0x31, self.load_immediate_to_stack_pointer)
         self.add_instruction(0x32, self.store_accumulator_to_memory)
         self.add_instruction(0x3A, self.load_memory_address_to_accumulator)
-        self.add_instruction(0x3C, self.increment_accumulator)
+        self.add_instruction(0x3C, lambda: self.increment_register(Registers.A))
         self.add_instruction(0x3E, self.move_immediate_to_register(Registers.A))
         self.add_instruction(0xC3, self.jump_to_address)
         self.add_instruction(0xC5, self.push_bc_to_stack)
@@ -69,15 +74,6 @@ class Intel8080(CPU):
         address = self.fetch_word()
         self.PC = address
 
-    def increment_accumulator(self) -> None:
-        """
-        Increment the accumulator (A register) by one.
-
-        This method increases the value stored in the accumulator by 0x01.
-        If the result exceeds 0xFF, it wraps around to 0x00.
-        """
-        self.registers[Registers.A] += 0x01
-
     def load_immediate_to_stack_pointer(self) -> None:
         """
         Load a 16-bit address from memory to the stack pointer (SP).
@@ -103,15 +99,6 @@ class Intel8080(CPU):
         h, l = self.split_word(self.PC)
         self.push(h, l)
         self.PC = address_to_jump
-
-    def increment_b_register(self) -> None:
-        """
-        Increment the B register by one.
-
-        This method increments the value in the B register by one. If the
-        result is greater than 0xFF, it wraps around to 0x00.
-        """
-        self.registers[Registers.B] += 0x01
 
     def increment_bc_register(self) -> None:
         """
@@ -248,3 +235,11 @@ class Intel8080(CPU):
             self.registers[register] = self.fetch_byte()
 
         return move_immediate_to_register_func
+
+    def increment_register(self, register: int) -> None:
+        """
+        Increment the value of the specified register by one.
+
+        This method increases the value stored in the specified register by 0x01.
+        """
+        self.registers[register] += 0x01

--- a/examples/tests.asm
+++ b/examples/tests.asm
@@ -24,4 +24,10 @@ load_from_memory:
 ; increment
 increment:
     INR a
+    INR b
+    INR c
+    INR d
+    INR e
+    INR h
+    INR l
     ret


### PR DESCRIPTION
<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds instructions to increment 8-bit registers in the Intel 8080 CPU emulator.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant CPU as Intel 8080 CPU
    participant Reg as Registers

    Note over CPU,Reg: New increment instructions added
    
    CPU->>Reg: increment_register(B) [0x04]
    CPU->>Reg: increment_register(C) [0x0C]
    CPU->>Reg: increment_register(D) [0x14]
    CPU->>Reg: increment_register(E) [0x1C]
    CPU->>Reg: increment_register(H) [0x24]
    CPU->>Reg: increment_register(L) [0x2C]
    CPU->>Reg: increment_register(A) [0x3C]
    
    Note over CPU,Reg: Each increment adds 0x01 to register value
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/JorgeJuarezM/xpire/pull/6/files#diff-648bd9784d6b736602a76a2e94f088c86cc4863e7dabec518145625e21528c33>cpus/intel_8080.py</a></td><td>Added lambda functions to increment various 8-bit registers and removed individual increment methods.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


