### PR TITLE
[FEAT] Implement DCR opcodes

### DIFF
--- a/examples/tests.asm
+++ b/examples/tests.asm
@@ -46,6 +46,7 @@ decrement:
     DCR e
     DCR h
     DCR l
+    ret
 
 
 increment_pairs:

--- a/examples/tests.asm
+++ b/examples/tests.asm
@@ -3,6 +3,7 @@ main:
     call load_immediate
     call load_from_memory
     call increment
+    call decrement
     call increment_pairs
     call jump
     call load_immediate_16
@@ -36,6 +37,16 @@ increment:
     INR h
     INR l
     ret
+
+decrement:
+    DCR a
+    DCR b
+    DCR c
+    DCR d
+    DCR e
+    DCR h
+    DCR l
+
 
 increment_pairs:
     INX bc

--- a/xpire/cpus/intel_8080.py
+++ b/xpire/cpus/intel_8080.py
@@ -225,7 +225,8 @@ class Intel8080(CPU):
 
         This method decreases the value stored in the specified register by 0x01.
         """
-        self.registers[register] -= 0x01
+        new_value = self.registers[register] - 0x01
+        self.registers[register] = new_value & 0xFF
 
     @manager.add_instruction(OPCodes.INR_BC, [Registers.B, Registers.C])
     @manager.add_instruction(OPCodes.INR_DE, [Registers.D, Registers.E])

--- a/xpire/cpus/intel_8080.py
+++ b/xpire/cpus/intel_8080.py
@@ -212,6 +212,21 @@ class Intel8080(CPU):
         """
         self.registers[register] += 0x01
 
+    @manager.add_instruction(OPCodes.DCR_A, [Registers.A])
+    @manager.add_instruction(OPCodes.DCR_B, [Registers.B])
+    @manager.add_instruction(OPCodes.DCR_C, [Registers.C])
+    @manager.add_instruction(OPCodes.DCR_D, [Registers.D])
+    @manager.add_instruction(OPCodes.DCR_E, [Registers.E])
+    @manager.add_instruction(OPCodes.DCR_H, [Registers.H])
+    @manager.add_instruction(OPCodes.DCR_L, [Registers.L])
+    def decrement_register(self, register: int) -> None:
+        """
+        Decrement the value of the specified register by one.
+
+        This method decreases the value stored in the specified register by 0x01.
+        """
+        self.registers[register] -= 0x01
+
     @manager.add_instruction(OPCodes.INR_BC, [Registers.B, Registers.C])
     @manager.add_instruction(OPCodes.INR_DE, [Registers.D, Registers.E])
     @manager.add_instruction(OPCodes.INR_HL, [Registers.H, Registers.L])

--- a/xpire/instructions/intel_8080.py
+++ b/xpire/instructions/intel_8080.py
@@ -11,6 +11,15 @@ INC_E = 0x1C
 INC_H = 0x24
 INC_L = 0x2C
 
+# Decrement 8-bit registers
+DCR_A = 0x3D
+DCR_B = 0x05
+DCR_C = 0x0D
+DCR_D = 0x15
+DCR_E = 0x1D
+DCR_H = 0x25
+DCR_L = 0x2D
+
 # Move immediate value to 8-bit register
 MVI_A = 0x3E
 MVI_B = 0x06


### PR DESCRIPTION
<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR implements the DCR (Decrement Register) opcodes for the Intel 8080 CPU, allowing for the decrementing of various 8-bit registers.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant CPU as Intel 8080 CPU
    participant Reg as Registers (A,B,C,D,E,H,L)
    
    Note over CPU,Reg: New Decrement Operations
    
    CPU->>Reg: DCR_A (0x3D)
    Reg-->>CPU: Decrease A by 0x01
    
    CPU->>Reg: DCR_B (0x05)
    Reg-->>CPU: Decrease B by 0x01
    
    CPU->>Reg: DCR_C (0x0D)
    Reg-->>CPU: Decrease C by 0x01
    
    CPU->>Reg: DCR_D (0x15)
    Reg-->>CPU: Decrease D by 0x01
    
    CPU->>Reg: DCR_E (0x1D)
    Reg-->>CPU: Decrease E by 0x01
    
    CPU->>Reg: DCR_H (0x25)
    Reg-->>CPU: Decrease H by 0x01
    
    CPU->>Reg: DCR_L (0x2D)
    Reg-->>CPU: Decrease L by 0x01
    
    Note over CPU,Reg: All results masked with 0xFF
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/JorgeJuarezM/xpire/pull/12/files#diff-791bf21915b24ec4d37d2698d8e8ce62c5a233d88d3729a8aa63c051bee9e44c>xpire/cpus/intel_8080.py</a></td><td>Added the decrement_register method to handle DCR opcodes for registers.</td></tr>
<tr><td><a href=https://github.com/JorgeJuarezM/xpire/pull/12/files#diff-4ead114c8fd72d4ebfce617122b1e3e9537f863b92331f71e417bf8f07a32711>xpire/instructions/intel_8080.py</a></td><td>Defined DCR opcodes for all 8-bit registers.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->






