### PR TITLE
[Feature]: Refactor flags to byte

### DIFF
--- a/tests/test_intel_8080.py
+++ b/tests/test_intel_8080.py
@@ -839,3 +839,67 @@ class TestIntel8080(unittest.TestCase):
 
         self.assertEqual(self.cpu.PC, 0x0002)
         self.assertEqual(self.cpu.SP, 0x0000)
+
+    def test_substract_immdiate_from_accumulator_with_borrow(self):
+        self.cpu.registers[Registers.A] = 0x14
+        self.cpu.memory[0x0000] = 0x21
+        self.cpu.substract_immediate_from_accumulator_with_borrow()
+
+        self.assertEqual(self.cpu.registers[Registers.A], 0xF3)
+        self.assertEqual(self.cpu.flags.S, True)
+        self.assertEqual(self.cpu.flags.Z, False)
+        self.assertEqual(self.cpu.flags.P, True)
+        self.assertEqual(self.cpu.flags.C, True)
+        self.assertEqual(self.cpu.flags.A, True)
+
+    def test_return_if_minus(self):
+        self.cpu.flags.S = True
+        self.cpu.PC = 0x0000
+        self.cpu.SP = 0x0000
+
+        self.cpu.memory[0x0000] = 0x42
+        self.cpu.memory[0x0001] = 0xBE
+
+        self.cpu.return_if_minus()
+
+        self.assertEqual(self.cpu.PC, 0xBE42)
+        self.assertEqual(self.cpu.SP, 0x0002)
+
+    def test_return_if_minus_opposite(self):
+        self.cpu.flags.S = False
+        self.cpu.PC = 0x0000
+        self.cpu.SP = 0x0000
+
+        self.cpu.memory[0x0000] = 0x42
+        self.cpu.memory[0x0001] = 0xBE
+
+        self.cpu.return_if_minus()
+
+        self.assertEqual(self.cpu.PC, 0x0000)
+        self.assertEqual(self.cpu.SP, 0x0000)
+
+    def test_return_if_parity_event(self):
+        self.cpu.flags.P = True
+        self.cpu.PC = 0x0000
+        self.cpu.SP = 0x0000
+
+        self.cpu.memory[0x0000] = 0x42
+        self.cpu.memory[0x0001] = 0xBE
+
+        self.cpu.return_if_parity_even()
+
+        self.assertEqual(self.cpu.PC, 0xBE42)
+        self.assertEqual(self.cpu.SP, 0x0002)
+
+    def test_return_if_parity_opposite(self):
+        self.cpu.flags.P = False
+        self.cpu.PC = 0x0000
+        self.cpu.SP = 0x0000
+
+        self.cpu.memory[0x0000] = 0x42
+        self.cpu.memory[0x0001] = 0xBE
+
+        self.cpu.return_if_parity_even()
+
+        self.assertEqual(self.cpu.PC, 0x0000)
+        self.assertEqual(self.cpu.SP, 0x0000)

--- a/tests/test_intel_8080.py
+++ b/tests/test_intel_8080.py
@@ -661,3 +661,58 @@ class TestIntel8080(unittest.TestCase):
         self.assertEqual(self.cpu.flags.P, False)
         self.assertEqual(self.cpu.flags.C, False)
         self.assertEqual(self.cpu.flags.A, False)
+
+    def test_jump_if_not_carry(self):
+        self.cpu.PC = 0x0000
+
+        self.cpu.flags.C = False
+        self.cpu.memory[0x0000] = 0x42
+        self.cpu.memory[0x0001] = 0xBE
+
+        self.cpu.jump_if_not_carry()
+
+        self.assertEqual(self.cpu.PC, 0xBE42)
+
+        self.cpu.PC = 0x0000
+        self.cpu.flags.clear_flags()
+        self.cpu.flags.C = True
+
+        self.cpu.jump_if_not_carry()
+
+        self.assertEqual(self.cpu.PC, 0x0002)
+
+    def test_jump_if_carry(self):
+        self.cpu.PC = 0x0000
+
+        self.cpu.flags.C = True
+        self.cpu.memory[0x0000] = 0x42
+        self.cpu.memory[0x0001] = 0xBE
+
+        self.cpu.jump_if_carry()
+
+        self.assertEqual(self.cpu.PC, 0xBE42)
+
+        self.cpu.PC = 0x0000
+        self.cpu.flags.clear_flags()
+        self.cpu.flags.C = False
+
+        self.cpu.jump_if_carry()
+
+        self.assertEqual(self.cpu.PC, 0x0002)
+
+    def test_push_and_pop_processor_state_word(self):
+        self.cpu.PC = 0x0000
+        self.cpu.SP = 0x0000
+        self.cpu.registers[Registers.A] = 0x14
+        self.cpu.flags.set_flags(0xFF)
+
+        self.cpu.push_processor_state_word()
+        self.cpu.registers[Registers.A] = 0x20
+        self.cpu.flags.clear_flags()
+
+        self.cpu.pop_processor_state_word()
+
+        self.assertEqual(self.cpu.PC, 0x0000)
+        self.assertEqual(self.cpu.SP, 0x0000)
+        self.assertEqual(self.cpu.registers[Registers.A], 0x14)
+        self.assertEqual(self.cpu.flags.get_flags(), 0xFF)

--- a/tests/test_intel_8080.py
+++ b/tests/test_intel_8080.py
@@ -61,48 +61,48 @@ class TestIntel8080(unittest.TestCase):
         assert self.cpu.fetch_byte() == 0x12, "Shoud fetch correct byte"
 
     def test_flags(self):
-        self.assertEqual(self.cpu.flags["Z"], False)
-        self.assertEqual(self.cpu.flags["S"], False)
-        self.assertEqual(self.cpu.flags["P"], False)
-        self.assertEqual(self.cpu.flags["C"], False)
-        self.assertEqual(self.cpu.flags["A"], False)
+        self.assertEqual(self.cpu.flags.Z, False)
+        self.assertEqual(self.cpu.flags.S, False)
+        self.assertEqual(self.cpu.flags.P, False)
+        self.assertEqual(self.cpu.flags.C, False)
+        self.assertEqual(self.cpu.flags.A, False)
 
         self.cpu.registers[Registers.B] = 0xFF
         self.cpu.registers[Registers.A] = 0xFF
         self.cpu.add_to_accumulator(Registers.B)
 
-        self.assertEqual(self.cpu.flags["Z"], False)
-        self.assertEqual(self.cpu.flags["S"], True)
-        self.assertEqual(self.cpu.flags["P"], False)
-        self.assertEqual(self.cpu.flags["C"], True)
-        self.assertEqual(self.cpu.flags["A"], True)
+        self.assertEqual(self.cpu.flags.Z, False)
+        self.assertEqual(self.cpu.flags.S, True)
+        self.assertEqual(self.cpu.flags.P, False)
+        self.assertEqual(self.cpu.flags.C, True)
+        self.assertEqual(self.cpu.flags.A, True)
 
     def test_icr_flags(self):
-        self.cpu.flags["Z"] = False
-        self.cpu.flags["S"] = False
-        self.cpu.flags["P"] = False
-        self.cpu.flags["C"] = False
-        self.cpu.flags["A"] = False
+        self.cpu.flags.Z = False
+        self.cpu.flags.S = False
+        self.cpu.flags.P = False
+        self.cpu.flags.C = False
+        self.cpu.flags.A = False
 
         self.cpu.registers[Registers.B] = 0xFE
         self.cpu.increment_register(Registers.B)
 
         self.assertEqual(self.cpu.registers[Registers.B], 0xFF)
-        self.assertEqual(self.cpu.flags["Z"], False)
-        self.assertEqual(self.cpu.flags["S"], True)
-        self.assertEqual(self.cpu.flags["P"], True)
-        self.assertEqual(self.cpu.flags["C"], False)
-        self.assertEqual(self.cpu.flags["A"], False)
+        self.assertEqual(self.cpu.flags.Z, False)
+        self.assertEqual(self.cpu.flags.S, True)
+        self.assertEqual(self.cpu.flags.P, True)
+        self.assertEqual(self.cpu.flags.C, False)
+        self.assertEqual(self.cpu.flags.A, False)
 
         self.cpu.registers[Registers.B] = 0xFF
         self.cpu.increment_register(Registers.B)
 
         self.assertEqual(self.cpu.registers[Registers.B], 0x00)
-        self.assertEqual(self.cpu.flags["Z"], True)
-        self.assertEqual(self.cpu.flags["S"], False)
-        self.assertEqual(self.cpu.flags["P"], True)
-        self.assertEqual(self.cpu.flags["C"], False)
-        self.assertEqual(self.cpu.flags["A"], True)
+        self.assertEqual(self.cpu.flags.Z, True)
+        self.assertEqual(self.cpu.flags.S, False)
+        self.assertEqual(self.cpu.flags.P, True)
+        self.assertEqual(self.cpu.flags.C, False)
+        self.assertEqual(self.cpu.flags.A, True)
 
     def test_add_to_accumulator(self):
         self.cpu.registers[Registers.A] = 0x2E
@@ -110,11 +110,11 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.add_to_accumulator(Registers.D)
 
         self.assertEqual(self.cpu.registers[Registers.A], 0x9A)
-        self.assertEqual(self.cpu.flags["Z"], False)
-        self.assertEqual(self.cpu.flags["S"], True)
-        self.assertEqual(self.cpu.flags["P"], True)
-        self.assertEqual(self.cpu.flags["C"], False)
-        self.assertEqual(self.cpu.flags["A"], True)
+        self.assertEqual(self.cpu.flags.Z, False)
+        self.assertEqual(self.cpu.flags.S, True)
+        self.assertEqual(self.cpu.flags.P, True)
+        self.assertEqual(self.cpu.flags.C, False)
+        self.assertEqual(self.cpu.flags.A, True)
 
     def test_register_and_register(self):
         self.cpu.registers[Registers.A] = 0xFC
@@ -122,10 +122,10 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.register_and_register(Registers.A, Registers.D)
 
         self.assertEqual(self.cpu.registers[Registers.A], 0x0C)
-        self.assertEqual(self.cpu.flags["S"], False)
-        self.assertEqual(self.cpu.flags["Z"], False)
-        self.assertEqual(self.cpu.flags["P"], True)
-        self.assertEqual(self.cpu.flags["C"], False)
+        self.assertEqual(self.cpu.flags.S, False)
+        self.assertEqual(self.cpu.flags.Z, False)
+        self.assertEqual(self.cpu.flags.P, True)
+        self.assertEqual(self.cpu.flags.C, False)
 
     def test_apply_xor_to_registers(self):
         self.cpu.registers[Registers.A] = 0xFC
@@ -140,11 +140,11 @@ class TestIntel8080(unittest.TestCase):
         self.assertEqual(self.cpu.registers[Registers.B], 0x00)
         self.assertEqual(self.cpu.registers[Registers.C], 0x00)
 
-        self.assertEqual(self.cpu.flags["S"], False)
-        self.assertEqual(self.cpu.flags["Z"], True)
-        self.assertEqual(self.cpu.flags["P"], True)
-        self.assertEqual(self.cpu.flags["C"], False)
-        self.assertEqual(self.cpu.flags["A"], False)
+        self.assertEqual(self.cpu.flags.S, False)
+        self.assertEqual(self.cpu.flags.Z, True)
+        self.assertEqual(self.cpu.flags.P, True)
+        self.assertEqual(self.cpu.flags.C, False)
+        self.assertEqual(self.cpu.flags.A, False)
 
     def test_apply_xor_to_registers_2(self):
         self.cpu.registers[Registers.A] = 0b11111111  # 0xFF
@@ -155,11 +155,11 @@ class TestIntel8080(unittest.TestCase):
         self.assertEqual(self.cpu.registers[Registers.A], 0b01000100)  # 0x44
         self.assertEqual(self.cpu.registers[Registers.B], 0b10111011)  # 0xBB
 
-        self.assertEqual(self.cpu.flags["S"], False)
-        self.assertEqual(self.cpu.flags["Z"], False)
-        self.assertEqual(self.cpu.flags["P"], True)
-        self.assertEqual(self.cpu.flags["C"], False)
-        self.assertEqual(self.cpu.flags["A"], False)
+        self.assertEqual(self.cpu.flags.S, False)
+        self.assertEqual(self.cpu.flags.Z, False)
+        self.assertEqual(self.cpu.flags.P, True)
+        self.assertEqual(self.cpu.flags.C, False)
+        self.assertEqual(self.cpu.flags.A, False)
 
     def test_register_or_with_accumulator(self):
         self.cpu.registers[Registers.A] = 0x33
@@ -170,11 +170,11 @@ class TestIntel8080(unittest.TestCase):
         self.assertEqual(self.cpu.registers[Registers.A], 0x3F)
         self.assertEqual(self.cpu.registers[Registers.C], 0x0F)
 
-        self.assertEqual(self.cpu.flags["S"], False)
-        self.assertEqual(self.cpu.flags["Z"], False)
-        self.assertEqual(self.cpu.flags["P"], True)
-        self.assertEqual(self.cpu.flags["C"], False)
-        self.assertEqual(self.cpu.flags["A"], False)
+        self.assertEqual(self.cpu.flags.S, False)
+        self.assertEqual(self.cpu.flags.Z, False)
+        self.assertEqual(self.cpu.flags.P, True)
+        self.assertEqual(self.cpu.flags.C, False)
+        self.assertEqual(self.cpu.flags.A, False)
 
     def test_rotate_right_accumulator(self):
         """
@@ -187,24 +187,24 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.rotate_right_a()
 
         self.assertEqual(self.cpu.registers[Registers.A], 0b1111001)  # 0x79
-        self.assertEqual(self.cpu.flags["S"], False)
-        self.assertEqual(self.cpu.flags["Z"], False)
-        self.assertEqual(self.cpu.flags["P"], False)
-        self.assertEqual(self.cpu.flags["C"], False)
-        self.assertEqual(self.cpu.flags["A"], False)
+        self.assertEqual(self.cpu.flags.S, False)
+        self.assertEqual(self.cpu.flags.Z, False)
+        self.assertEqual(self.cpu.flags.P, False)
+        self.assertEqual(self.cpu.flags.C, False)
+        self.assertEqual(self.cpu.flags.A, False)
 
     def test_rotate_right_a_through_carry(self):
         self.cpu.registers[Registers.A] = 0b01101010  # 0x6A
-        self.cpu.flags["C"] = True
+        self.cpu.flags.C = True
 
         self.cpu.rotate_right_a_through_carry()
 
         self.assertEqual(self.cpu.registers[Registers.A], 0b10110101)  # 0xB5
-        self.assertEqual(self.cpu.flags["S"], False)
-        self.assertEqual(self.cpu.flags["Z"], False)
-        self.assertEqual(self.cpu.flags["P"], False)
-        self.assertEqual(self.cpu.flags["C"], False)
-        self.assertEqual(self.cpu.flags["A"], False)
+        self.assertEqual(self.cpu.flags.S, False)
+        self.assertEqual(self.cpu.flags.Z, False)
+        self.assertEqual(self.cpu.flags.P, False)
+        self.assertEqual(self.cpu.flags.C, False)
+        self.assertEqual(self.cpu.flags.A, False)
 
     def test_sum_register_pair_with_hl(self):
         self.cpu.registers[Registers.B] = 0x33
@@ -218,11 +218,11 @@ class TestIntel8080(unittest.TestCase):
         self.assertEqual(self.cpu.registers[Registers.H], 0xD5)
         self.assertEqual(self.cpu.registers[Registers.L], 0x1A)
 
-        self.assertEqual(self.cpu.flags["S"], False)
-        self.assertEqual(self.cpu.flags["Z"], False)
-        self.assertEqual(self.cpu.flags["P"], False)
-        self.assertEqual(self.cpu.flags["C"], False)
-        self.assertEqual(self.cpu.flags["A"], False)
+        self.assertEqual(self.cpu.flags.S, False)
+        self.assertEqual(self.cpu.flags.Z, False)
+        self.assertEqual(self.cpu.flags.P, False)
+        self.assertEqual(self.cpu.flags.C, False)
+        self.assertEqual(self.cpu.flags.A, False)
 
     def test_exchange_register_pairs(self):
         self.cpu.registers[Registers.H] = 0x00
@@ -250,11 +250,11 @@ class TestIntel8080(unittest.TestCase):
 
         self.cpu.add_immediate_to_accumulator()
         self.assertEqual(self.cpu.registers[Registers.A], 0x14)
-        self.assertEqual(self.cpu.flags["S"], False)
-        self.assertEqual(self.cpu.flags["Z"], False)
-        self.assertEqual(self.cpu.flags["P"], True)
-        self.assertEqual(self.cpu.flags["C"], True)
-        self.assertEqual(self.cpu.flags["A"], True)
+        self.assertEqual(self.cpu.flags.S, False)
+        self.assertEqual(self.cpu.flags.Z, False)
+        self.assertEqual(self.cpu.flags.P, True)
+        self.assertEqual(self.cpu.flags.C, True)
+        self.assertEqual(self.cpu.flags.A, True)
 
     def test_read_memory_word_bytes(self):
         """
@@ -304,11 +304,11 @@ class TestIntel8080(unittest.TestCase):
         self.assertEqual(self.cpu.registers[Registers.A], 0x42)
         self.assertEqual(self.cpu.registers[Registers.C], 0x0F)
 
-        self.assertEqual(self.cpu.flags["S"], False)
-        self.assertEqual(self.cpu.flags["Z"], False)
-        self.assertEqual(self.cpu.flags["P"], True)
-        self.assertEqual(self.cpu.flags["C"], False)
-        self.assertEqual(self.cpu.flags["A"], True)
+        self.assertEqual(self.cpu.flags.S, False)
+        self.assertEqual(self.cpu.flags.Z, False)
+        self.assertEqual(self.cpu.flags.P, True)
+        self.assertEqual(self.cpu.flags.C, False)
+        self.assertEqual(self.cpu.flags.A, True)
 
     def test_exchange_sp_with_hl(self):
 
@@ -335,11 +335,11 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.increment_memory_address()
 
         self.assertEqual(self.cpu.memory[0x0000], 0x1A)
-        self.assertEqual(self.cpu.flags["S"], False)
-        self.assertEqual(self.cpu.flags["Z"], False)
-        self.assertEqual(self.cpu.flags["P"], False)
-        self.assertEqual(self.cpu.flags["C"], False)
-        self.assertEqual(self.cpu.flags["A"], False)
+        self.assertEqual(self.cpu.flags.S, False)
+        self.assertEqual(self.cpu.flags.Z, False)
+        self.assertEqual(self.cpu.flags.P, False)
+        self.assertEqual(self.cpu.flags.C, False)
+        self.assertEqual(self.cpu.flags.A, False)
 
     def test_accumulator_and_immediate(self):
         self.cpu.registers[Registers.A] = 0x14
@@ -349,16 +349,16 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.accumulator_and_immediate()
 
         self.assertEqual(self.cpu.registers[Registers.A], 0x00)
-        self.assertEqual(self.cpu.flags["S"], False)
-        self.assertEqual(self.cpu.flags["Z"], True)
-        self.assertEqual(self.cpu.flags["P"], True)
-        self.assertEqual(self.cpu.flags["C"], False)
-        self.assertEqual(self.cpu.flags["A"], False)
+        self.assertEqual(self.cpu.flags.S, False)
+        self.assertEqual(self.cpu.flags.Z, True)
+        self.assertEqual(self.cpu.flags.P, True)
+        self.assertEqual(self.cpu.flags.C, False)
+        self.assertEqual(self.cpu.flags.A, False)
 
     def test_jump_if_minus(self):
         self.cpu.PC = 0x0000
 
-        self.cpu.flags["S"] = True
+        self.cpu.flags.S = True
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
@@ -369,7 +369,7 @@ class TestIntel8080(unittest.TestCase):
     def test_jump_if_minus_opposite(self):
         self.cpu.PC = 0x0000
 
-        self.cpu.flags["S"] = False
+        self.cpu.flags.S = False
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
@@ -385,11 +385,11 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.substract_immediate_from_accumulator()
 
         self.assertEqual(self.cpu.registers[Registers.A], 0xD2)
-        self.assertEqual(self.cpu.flags["S"], True)
-        self.assertEqual(self.cpu.flags["Z"], False)
-        self.assertEqual(self.cpu.flags["P"], True)
-        self.assertEqual(self.cpu.flags["C"], True)
-        self.assertEqual(self.cpu.flags["A"], True)
+        self.assertEqual(self.cpu.flags.S, True)
+        self.assertEqual(self.cpu.flags.Z, False)
+        self.assertEqual(self.cpu.flags.P, True)
+        self.assertEqual(self.cpu.flags.C, True)
+        self.assertEqual(self.cpu.flags.A, True)
 
     def test_compare_register_with_accumulator(self):
         self.cpu.registers[Registers.A] = 0x14
@@ -397,11 +397,11 @@ class TestIntel8080(unittest.TestCase):
 
         self.cpu.compare_register_with_accumulator(Registers.C)
 
-        self.assertEqual(self.cpu.flags["S"], False)
-        self.assertEqual(self.cpu.flags["Z"], True)
-        self.assertEqual(self.cpu.flags["P"], False)
-        self.assertEqual(self.cpu.flags["C"], False)
-        self.assertEqual(self.cpu.flags["A"], True)
+        self.assertEqual(self.cpu.flags.S, False)
+        self.assertEqual(self.cpu.flags.Z, True)
+        self.assertEqual(self.cpu.flags.P, False)
+        self.assertEqual(self.cpu.flags.C, False)
+        self.assertEqual(self.cpu.flags.A, True)
 
     def test_compare_register_with_accumulator_opposite(self):
         self.cpu.registers[Registers.A] = 0x14
@@ -409,14 +409,14 @@ class TestIntel8080(unittest.TestCase):
 
         self.cpu.compare_register_with_accumulator(Registers.C)
 
-        self.assertEqual(self.cpu.flags["S"], True)
-        self.assertEqual(self.cpu.flags["Z"], False)
-        self.assertEqual(self.cpu.flags["P"], False)
-        self.assertEqual(self.cpu.flags["C"], True)
-        self.assertEqual(self.cpu.flags["A"], True)
+        self.assertEqual(self.cpu.flags.S, True)
+        self.assertEqual(self.cpu.flags.Z, False)
+        self.assertEqual(self.cpu.flags.P, False)
+        self.assertEqual(self.cpu.flags.C, True)
+        self.assertEqual(self.cpu.flags.A, True)
 
     def test_call_if_not_carry(self):
-        self.cpu.flags["C"] = False
+        self.cpu.flags.C = False
         self.cpu.PC = 0x0000
         self.cpu.SP = 0x0000
 
@@ -429,7 +429,7 @@ class TestIntel8080(unittest.TestCase):
         self.assertEqual(self.cpu.SP, 0xFFFE)
 
     def test_call_if_not_carry_opposite(self):
-        self.cpu.flags["C"] = True
+        self.cpu.flags.C = True
         self.cpu.PC = 0x0000
         self.cpu.SP = 0x0000
 
@@ -448,11 +448,11 @@ class TestIntel8080(unittest.TestCase):
 
         self.cpu.compare_register_with_memory()
 
-        self.assertEqual(self.cpu.flags["S"], False)
-        self.assertEqual(self.cpu.flags["Z"], True)
-        self.assertEqual(self.cpu.flags["P"], False)
-        self.assertEqual(self.cpu.flags["C"], False)
-        self.assertEqual(self.cpu.flags["A"], True)
+        self.assertEqual(self.cpu.flags.S, False)
+        self.assertEqual(self.cpu.flags.Z, True)
+        self.assertEqual(self.cpu.flags.P, False)
+        self.assertEqual(self.cpu.flags.C, False)
+        self.assertEqual(self.cpu.flags.A, True)
 
     def test_compare_register_with_memory_opposite(self):
         self.cpu.registers[Registers.A] = 0x14
@@ -461,11 +461,11 @@ class TestIntel8080(unittest.TestCase):
 
         self.cpu.compare_register_with_memory()
 
-        self.assertEqual(self.cpu.flags["S"], True)
-        self.assertEqual(self.cpu.flags["Z"], False)
-        self.assertEqual(self.cpu.flags["P"], True)
-        self.assertEqual(self.cpu.flags["C"], True)
-        self.assertEqual(self.cpu.flags["A"], True)
+        self.assertEqual(self.cpu.flags.S, True)
+        self.assertEqual(self.cpu.flags.Z, False)
+        self.assertEqual(self.cpu.flags.P, True)
+        self.assertEqual(self.cpu.flags.C, True)
+        self.assertEqual(self.cpu.flags.A, True)
 
     def test_substract_register_from_accumulator(self):
         self.cpu.registers[Registers.A] = 0x14
@@ -474,11 +474,11 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.substract_register_from_accumulator(Registers.C)
 
         self.assertEqual(self.cpu.registers[Registers.A], 0x00)
-        self.assertEqual(self.cpu.flags["S"], False)
-        self.assertEqual(self.cpu.flags["Z"], True)
-        self.assertEqual(self.cpu.flags["P"], True)
-        self.assertEqual(self.cpu.flags["C"], False)
-        self.assertEqual(self.cpu.flags["A"], True)
+        self.assertEqual(self.cpu.flags.S, False)
+        self.assertEqual(self.cpu.flags.Z, True)
+        self.assertEqual(self.cpu.flags.P, True)
+        self.assertEqual(self.cpu.flags.C, False)
+        self.assertEqual(self.cpu.flags.A, True)
 
     @patch("xpire.machine.Screen", MockScreen)
     @patch("xpire.machine.pygame.event", MockPygameEvent())

--- a/tests/test_intel_8080.py
+++ b/tests/test_intel_8080.py
@@ -501,3 +501,163 @@ class TestIntel8080(unittest.TestCase):
         machine = Machine()
         machine.process_input()
         self.assertFalse(machine.running)
+
+    def test_decrement_register(self):
+        self.cpu.registers[Registers.A] = 0x14
+        self.cpu.decrement_register(Registers.A)
+
+        self.assertEqual(self.cpu.registers[Registers.A], 0x13)
+        self.assertEqual(self.cpu.flags.S, False)
+        self.assertEqual(self.cpu.flags.Z, False)
+        self.assertEqual(self.cpu.flags.P, False)
+        self.assertEqual(self.cpu.flags.C, False)
+        self.assertEqual(self.cpu.flags.A, False)
+
+    def test_jump_if_not_zero(self):
+        self.cpu.PC = 0x0000
+
+        self.cpu.flags.Z = False
+        self.cpu.memory[0x0000] = 0x42
+        self.cpu.memory[0x0001] = 0xBE
+
+        self.cpu.jump_if_not_zero()
+
+        self.assertEqual(self.cpu.PC, 0xBE42)
+
+        self.cpu.PC = 0x0000
+        self.cpu.flags.clear_flags()
+        self.cpu.flags.Z = True
+
+        self.cpu.jump_if_not_zero()
+
+        self.assertEqual(self.cpu.PC, 0x0002)
+
+    def test_compare_register_with_immediate(self):
+        self.cpu.registers[Registers.A] = 0x14
+        self.cpu.memory[0x0000] = 0x14
+
+        self.cpu.compare_register_with_immediate(Registers.A)
+
+        self.assertEqual(self.cpu.flags.S, False)
+        self.assertEqual(self.cpu.flags.Z, True)
+        self.assertEqual(self.cpu.flags.P, False)
+        self.assertEqual(self.cpu.flags.C, False)
+        self.assertEqual(self.cpu.flags.A, True)
+
+    def test_return_if_not_carry(self):
+        self.cpu.flags.C = False
+        self.cpu.PC = 0x0000
+        self.cpu.SP = 0x0000
+
+        self.cpu.memory[0x0000] = 0x42
+        self.cpu.memory[0x0001] = 0xBE
+
+        self.cpu.return_if_not_carry()
+
+        self.assertEqual(self.cpu.PC, 0xBE42)
+        self.assertEqual(self.cpu.SP, 0x0002)
+
+    def test_return_if_not_carry_opposite(self):
+        self.cpu.flags.C = True
+        self.cpu.PC = 0x0000
+        self.cpu.SP = 0x0000
+
+        self.cpu.memory[0x0000] = 0x42
+        self.cpu.memory[0x0001] = 0xBE
+
+        self.cpu.return_if_not_carry()
+
+        self.assertEqual(self.cpu.PC, 0x0000)
+        self.assertEqual(self.cpu.SP, 0x0000)
+
+    def test_return_if_carry(self):
+        self.cpu.flags.C = True
+        self.cpu.PC = 0x0000
+        self.cpu.SP = 0x0000
+
+        self.cpu.memory[0x0000] = 0x42
+        self.cpu.memory[0x0001] = 0xBE
+
+        self.cpu.return_if_carry()
+
+        self.assertEqual(self.cpu.PC, 0xBE42)
+        self.assertEqual(self.cpu.SP, 0x0002)
+
+    def test_return_if_carry_opposite(self):
+        self.cpu.flags.C = False
+        self.cpu.PC = 0x0000
+        self.cpu.SP = 0x0000
+
+        self.cpu.memory[0x0000] = 0x42
+        self.cpu.memory[0x0001] = 0xBE
+
+        self.cpu.return_if_carry()
+
+        self.assertEqual(self.cpu.PC, 0x0000)
+        self.assertEqual(self.cpu.SP, 0x0000)
+
+    def test_register_or_with_memory(self):
+        self.cpu.registers[Registers.A] = 0x14
+        self.cpu.PC = 0x0000
+
+        self.cpu.memory[0x0000] = 0x14
+        self.cpu.registers[Registers.H] = 0x00
+        self.cpu.registers[Registers.L] = 0x00
+
+        self.cpu.register_or_with_memory(Registers.A)
+
+        self.assertEqual(self.cpu.registers[Registers.A], 0x14)
+        self.assertEqual(self.cpu.flags.S, False)
+        self.assertEqual(self.cpu.flags.Z, False)
+        self.assertEqual(self.cpu.flags.P, True)
+        self.assertEqual(self.cpu.flags.C, False)
+        self.assertEqual(self.cpu.flags.A, False)
+
+    def test_jump_if_zero(self):
+        self.cpu.PC = 0x0000
+
+        self.cpu.flags.Z = True
+        self.cpu.memory[0x0000] = 0x42
+        self.cpu.memory[0x0001] = 0xBE
+
+        self.cpu.jump_if_zero()
+
+        self.assertEqual(self.cpu.PC, 0xBE42)
+
+        self.cpu.PC = 0x0000
+        self.cpu.flags.clear_flags()
+        self.cpu.flags.Z = False
+
+        self.cpu.jump_if_zero()
+
+        self.assertEqual(self.cpu.PC, 0x0002)
+
+    def test_jump_if_parity(self):
+        self.cpu.PC = 0x0000
+
+        self.cpu.flags.P = True
+        self.cpu.memory[0x0000] = 0x42
+        self.cpu.memory[0x0001] = 0xBE
+
+        self.cpu.jump_if_parity()
+
+        self.assertEqual(self.cpu.PC, 0xBE42)
+
+        self.cpu.PC = 0x0000
+        self.cpu.flags.clear_flags()
+        self.cpu.flags.P = False
+
+        self.cpu.jump_if_parity()
+
+        self.assertEqual(self.cpu.PC, 0x0002)
+
+    def test_rotate_left_accumulator(self):
+        self.cpu.registers[Registers.A] = 0x14
+        self.cpu.rotate_left_accumulator()
+
+        self.assertEqual(self.cpu.registers[Registers.A], 0x28)
+        self.assertEqual(self.cpu.flags.S, False)
+        self.assertEqual(self.cpu.flags.Z, False)
+        self.assertEqual(self.cpu.flags.P, False)
+        self.assertEqual(self.cpu.flags.C, False)
+        self.assertEqual(self.cpu.flags.A, False)

--- a/tests/test_intel_8080.py
+++ b/tests/test_intel_8080.py
@@ -716,3 +716,126 @@ class TestIntel8080(unittest.TestCase):
         self.assertEqual(self.cpu.SP, 0x0000)
         self.assertEqual(self.cpu.registers[Registers.A], 0x14)
         self.assertEqual(self.cpu.flags.get_flags(), 0xFF)
+
+    def test_set_carry_flag(self):
+        self.cpu.set_carry()
+        self.assertEqual(self.cpu.flags.C, True)
+        self.assertEqual(self.cpu.flags.S, False)
+        self.assertEqual(self.cpu.flags.Z, False)
+        self.assertEqual(self.cpu.flags.P, False)
+        self.assertEqual(self.cpu.flags.A, False)
+
+    def test_return_if_zero(self):
+        self.cpu.flags.Z = True
+        self.cpu.PC = 0x0000
+        self.cpu.SP = 0x0000
+
+        self.cpu.memory[0x0000] = 0x42
+        self.cpu.memory[0x0001] = 0xBE
+
+        self.cpu.return_if_zero()
+
+        self.assertEqual(self.cpu.PC, 0xBE42)
+        self.assertEqual(self.cpu.SP, 0x0002)
+
+    def test_return_if_zero_opposite(self):
+        self.cpu.flags.Z = False
+        self.cpu.PC = 0x0000
+        self.cpu.SP = 0x0000
+
+        self.cpu.memory[0x0000] = 0x42
+        self.cpu.memory[0x0001] = 0xBE
+
+        self.cpu.return_if_zero()
+
+        self.assertEqual(self.cpu.PC, 0x0000)
+        self.assertEqual(self.cpu.SP, 0x0000)
+
+    def test_return_if_not_zero(self):
+        self.cpu.flags.Z = False
+        self.cpu.PC = 0x0000
+        self.cpu.SP = 0x0000
+
+        self.cpu.memory[0x0000] = 0x42
+        self.cpu.memory[0x0001] = 0xBE
+
+        self.cpu.return_if_not_zero()
+
+        self.assertEqual(self.cpu.PC, 0xBE42)
+        self.assertEqual(self.cpu.SP, 0x0002)
+
+    def test_return_if_not_zero_opposite(self):
+        self.cpu.flags.Z = True
+        self.cpu.PC = 0x0000
+        self.cpu.SP = 0x0000
+
+        self.cpu.memory[0x0000] = 0x42
+        self.cpu.memory[0x0001] = 0xBE
+
+        self.cpu.return_if_not_zero()
+
+        self.assertEqual(self.cpu.PC, 0x0000)
+        self.assertEqual(self.cpu.SP, 0x0000)
+
+    def test_decrement_memory_byte(self):
+        self.cpu.memory[0x0000] = 0x14
+        self.cpu.decrement_memory_byte()
+
+        self.assertEqual(self.cpu.memory[0x0000], 0x13)
+        self.assertEqual(self.cpu.flags.S, False)
+        self.assertEqual(self.cpu.flags.Z, False)
+        self.assertEqual(self.cpu.flags.P, False)
+        self.assertEqual(self.cpu.flags.C, False)
+        self.assertEqual(self.cpu.flags.A, False)
+
+    def test_call_if_zero(self):
+        self.cpu.flags.Z = True
+        self.cpu.PC = 0x0000
+        self.cpu.SP = 0x0000
+
+        self.cpu.memory[0x0000] = 0x42
+        self.cpu.memory[0x0001] = 0xBE
+
+        self.cpu.call_if_zero()
+
+        self.assertEqual(self.cpu.PC, 0xBE42)
+        self.assertEqual(self.cpu.SP, 0xFFFE)
+
+    def test_call_if_zero_opposite(self):
+        self.cpu.flags.Z = False
+        self.cpu.PC = 0x0000
+        self.cpu.SP = 0x0000
+
+        self.cpu.memory[0x0000] = 0x42
+        self.cpu.memory[0x0001] = 0xBE
+
+        self.cpu.call_if_zero()
+
+        self.assertEqual(self.cpu.PC, 0x0002)
+        self.assertEqual(self.cpu.SP, 0x0000)
+
+    def test_call_if_not_zero(self):
+        self.cpu.flags.Z = False
+        self.cpu.PC = 0x0000
+        self.cpu.SP = 0x0000
+
+        self.cpu.memory[0x0000] = 0x42
+        self.cpu.memory[0x0001] = 0xBE
+
+        self.cpu.call_if_not_zero()
+
+        self.assertEqual(self.cpu.PC, 0xBE42)
+        self.assertEqual(self.cpu.SP, 0xFFFE)
+
+    def test_call_if_not_zero_opposite(self):
+        self.cpu.flags.Z = True
+        self.cpu.PC = 0x0000
+        self.cpu.SP = 0x0000
+
+        self.cpu.memory[0x0000] = 0x42
+        self.cpu.memory[0x0001] = 0xBE
+
+        self.cpu.call_if_not_zero()
+
+        self.assertEqual(self.cpu.PC, 0x0002)
+        self.assertEqual(self.cpu.SP, 0x0000)

--- a/tests/test_intel_8080.py
+++ b/tests/test_intel_8080.py
@@ -929,3 +929,15 @@ class TestIntel8080(unittest.TestCase):
 
         self.assertEqual(self.cpu.PC, 0x02)
         self.assertEqual(self.cpu.SP, 0x0000)
+
+    def test_and_memory_to_accumulator(self):
+        self.cpu.registers[Registers.A] = 0xCC
+        self.cpu.memory[0x0000] = 0x0F
+        self.cpu.and_memory_to_accumulator()
+
+        self.assertEqual(self.cpu.registers[Registers.A], 0x0C)
+        self.assertEqual(self.cpu.flags.S, False)
+        self.assertEqual(self.cpu.flags.Z, False)
+        self.assertEqual(self.cpu.flags.P, True)
+        self.assertEqual(self.cpu.flags.C, False)
+        self.assertEqual(self.cpu.flags.A, True)

--- a/tests/test_intel_8080.py
+++ b/tests/test_intel_8080.py
@@ -903,3 +903,29 @@ class TestIntel8080(unittest.TestCase):
 
         self.assertEqual(self.cpu.PC, 0x0000)
         self.assertEqual(self.cpu.SP, 0x0000)
+
+    def test_call_if_parity_even(self):
+        self.cpu.flags.P = True
+        self.cpu.PC = 0x0000
+        self.cpu.SP = 0x0000
+
+        self.cpu.memory[0x0000] = 0x42
+        self.cpu.memory[0x0001] = 0xBE
+
+        self.cpu.call_if_parity_even()
+
+        self.assertEqual(self.cpu.PC, 0xBE42)
+        self.assertEqual(self.cpu.SP, 0xFFFE)
+
+    def test_call_if_parity_even_opposite(self):
+        self.cpu.flags.P = False
+        self.cpu.PC = 0x0000
+        self.cpu.SP = 0x0000
+
+        self.cpu.memory[0x0000] = 0x42
+        self.cpu.memory[0x0001] = 0xBE
+
+        self.cpu.call_if_parity_even()
+
+        self.assertEqual(self.cpu.PC, 0x02)
+        self.assertEqual(self.cpu.SP, 0x0000)

--- a/xpire/cpus/cpu.py
+++ b/xpire/cpus/cpu.py
@@ -10,6 +10,7 @@ import xpire.instructions.common as OPCodes
 from xpire.cpus.abstract import AbstractCPU
 from xpire.decorators import increment_program_counter
 from xpire.exceptions import SystemHalt
+from xpire.flags import FlagsManager
 from xpire.instructions.manager import InstructionManager as manager
 from xpire.memory import Memory
 from xpire.registers.register import RegisterManager
@@ -59,6 +60,8 @@ class CPU(AbstractCPU):
         self.cycles = 0x00
         self.interrupts_enabled = False
         self.halted = False
+
+        self.flags = FlagsManager()
 
     def execute_instruction(self) -> None:
         """

--- a/xpire/cpus/intel_8080.py
+++ b/xpire/cpus/intel_8080.py
@@ -34,11 +34,11 @@ class Intel8080(CPU):
 
         self.out = {}
 
-        self.flags["Z"] = False  # Zero flag
-        self.flags["S"] = False  # Sign flag
-        self.flags["P"] = False  # Parity flag
-        self.flags["C"] = False  # Carry flag
-        self.flags["A"] = False  # Aux carry flag
+        # self.flags["Z"] = False  # Zero flag
+        # self.flags["S"] = False  # Sign flag
+        # self.flags["P"] = False  # Parity flag
+        # self.flags["C"] = False  # Carry flag
+        # self.flags["A"] = False  # Aux carry flag
 
         self.interrupts_enabled = False
 
@@ -87,22 +87,22 @@ class Intel8080(CPU):
         return self.read_memory_word_bytes(self.SP)
 
     def set_flags(self, value: int, mask: int = 0xFF) -> None:
-        self.flags["Z"] = value == 0x00
-        self.flags["S"] = bool(value & 0x80)
-        self.flags["P"] = self.check_parity(value, mask)
+        self.flags.Z = value == 0x00
+        self.flags.S = bool(value & 0x80)
+        self.flags.P = self.check_parity(value, mask)
 
     def check_parity(self, value: int, mask: int = 0xFF) -> bool:
         return (bin(value & mask).count("1") % 2) == 0
 
     def set_carry_flag(self, value: int, mask: int = 0xFF) -> None:
-        self.flags["C"] = value > mask or value < 0x00
+        self.flags.C = value > mask or value < 0x00
 
     def set_aux_carry_flag(self, a: int, b: int, mask: int = 0x0F) -> None:
         result = (a & mask) + (b & mask)
         if result > mask or result < 0x00:
-            self.flags["A"] = True
+            self.flags.A = True
         else:
-            self.flags["A"] = False
+            self.flags.A = False
 
     @manager.add_instruction(OPCodes.LDA)
     def load_memory_address_to_accumulator(self) -> None:
@@ -278,7 +278,7 @@ class Intel8080(CPU):
         self.registers[register] = new_value
 
         self.set_flags(new_value)
-        self.flags["A"] = ((result & 0xF) - 1) > 0xF
+        self.flags.A = ((result & 0xF) - 1) > 0xF
         self.cycles += 5
 
     @manager.add_instruction(OPCodes.INX_BC, [Registers.B, Registers.C])
@@ -327,7 +327,7 @@ class Intel8080(CPU):
     @manager.add_instruction(OPCodes.JNZ)
     def jump_if_not_zero(self) -> None:
         address = self.fetch_word()
-        if not self.flags["Z"]:
+        if not self.flags.Z:
             self.PC = address
 
         self.cycles += 10
@@ -378,10 +378,10 @@ class Intel8080(CPU):
 
         self.set_flags(result & 0xFF)
         self.set_carry_flag(result)
-        self.flags["P"] = (bin(r).count("1") % 2) == 0
+        self.flags.P = (bin(r).count("1") % 2) == 0
         lsb_a = a_value & 0xF
         lsb_i = tc_val & 0xF
-        self.flags["A"] = (lsb_a + lsb_i) > 0xF
+        self.flags.A = (lsb_a + lsb_i) > 0xF
 
         self.cycles += 7
 
@@ -456,7 +456,7 @@ class Intel8080(CPU):
 
     @manager.add_instruction(OPCodes.RNC)
     def return_if_not_carry(self) -> None:
-        if not self.flags["C"]:
+        if not self.flags.C:
             h, l = self.pop()
             self.PC = join_bytes(h, l)
             self.cycles += 11
@@ -466,7 +466,7 @@ class Intel8080(CPU):
 
     @manager.add_instruction(OPCodes.RC)
     def return_if_carry(self) -> None:
-        if self.flags["C"]:
+        if self.flags.C:
             h, l = self.pop()
             self.PC = join_bytes(h, l)
             self.cycles += 11
@@ -503,8 +503,8 @@ class Intel8080(CPU):
         self.registers[Registers.A] = result
 
         self.set_flags(result)
-        self.flags["C"] = False
-        self.flags["A"] = False
+        self.flags.C = False
+        self.flags.A = False
 
         self.cycles += 4
 
@@ -521,7 +521,7 @@ class Intel8080(CPU):
         self.registers[register] = result
 
         self.set_flags(result)
-        self.flags["C"] = False
+        self.flags.C = False
 
         self.cycles += 7
 
@@ -548,7 +548,7 @@ class Intel8080(CPU):
     @manager.add_instruction(OPCodes.JZ)
     def jump_if_zero(self) -> None:
         address = self.fetch_word()
-        if self.flags["Z"]:
+        if self.flags.Z:
             self.PC = address
 
         self.cycles += 10
@@ -580,7 +580,7 @@ class Intel8080(CPU):
     @manager.add_instruction(OPCodes.JPE)
     def jump_if_parity(self) -> None:
         address = self.fetch_word()
-        if self.flags.get("P"):
+        if self.flags.P:
             self.PC = address
             self.cycles += 10
             return
@@ -609,7 +609,7 @@ class Intel8080(CPU):
 
         Condition bits affected: Carry.
         """
-        carry = 1 if self.flags["C"] else 0
+        carry = 1 if self.flags.C else 0
         accumulator = self.registers[Registers.A] & 0xFF
 
         # Obtener el bit menos significativo (LSB) del acumulador
@@ -623,7 +623,7 @@ class Intel8080(CPU):
         accumulator = accumulator & 0xFF
 
         self.registers[Registers.A] = accumulator
-        self.flags["C"] = True if new_carry else False
+        self.flags.C = True if new_carry else False
 
         self.cycles += 4
 
@@ -651,7 +651,7 @@ class Intel8080(CPU):
         accumulator = accumulator & 0xFF
 
         self.registers[Registers.A] = accumulator
-        self.flags["C"] = True if new_carry else False
+        self.flags.C = True if new_carry else False
 
         self.cycles += 4
 
@@ -679,14 +679,14 @@ class Intel8080(CPU):
         accumulator = accumulator & 0xFF
 
         self.registers[Registers.A] = accumulator
-        self.flags["C"] = True if new_carry else False
+        self.flags.C = True if new_carry else False
 
         self.cycles += 4
 
     @manager.add_instruction(OPCodes.JNC)
     def jump_if_not_carry(self) -> None:
         address = self.fetch_word()
-        if not self.flags["C"]:
+        if not self.flags.C:
             self.PC = address
 
         self.cycles += 10
@@ -694,32 +694,20 @@ class Intel8080(CPU):
     @manager.add_instruction(OPCodes.JC)
     def jump_if_carry(self) -> None:
         address = self.fetch_word()
-        if self.flags["C"]:
+        if self.flags.C:
             self.PC = address
 
         self.cycles += 10
 
     @manager.add_instruction(OPCodes.PUSH_PSW)
     def push_processor_state_word(self) -> None:
-        flags_byte = self.flags.get("S") << 0x07
-        flags_byte |= self.flags.get("Z") << 0x06
-        flags_byte |= self.flags.get("A") << 0x04
-        flags_byte |= self.flags.get("P") << 0x02
-        flags_byte |= 0x02
-        flags_byte |= self.flags.get("C") << 0x00
-
-        self.push(self.registers[Registers.A], flags_byte)
+        self.push(self.registers[Registers.A], self.flags.get_flags())
         self.cycles += 11
 
     @manager.add_instruction(OPCodes.POP_PSW)
     def pop_processor_state_word(self) -> None:
         self.registers[Registers.A], flags_byte = self.pop()
-        self.flags["S"] = bool((flags_byte >> 0x07) & 0x01)
-        self.flags["Z"] = bool((flags_byte >> 0x06) & 0x01)
-        self.flags["A"] = bool((flags_byte >> 0x04) & 0x01)
-        self.flags["P"] = bool((flags_byte >> 0x02) & 0x01)
-        self.flags["C"] = bool((flags_byte >> 0x00) & 0x01)
-
+        self.flags.set_flags(flags_byte)
         self.cycles += 10
 
     @manager.add_instruction(OPCodes.ANI)
@@ -731,7 +719,7 @@ class Intel8080(CPU):
         self.registers[Registers.A] = result
 
         self.set_flags(result)
-        self.flags["C"] = False
+        self.flags.C = False
         self.set_aux_carry_flag(value1, value2)
 
         self.cycles += 7
@@ -739,7 +727,7 @@ class Intel8080(CPU):
     @manager.add_instruction(OPCodes.JM)
     def jump_if_minus(self) -> None:
         address = self.fetch_word()
-        if self.flags["S"]:
+        if self.flags.S:
             self.PC = address
 
         self.cycles += 10
@@ -783,9 +771,9 @@ class Intel8080(CPU):
         result = value1 ^ value2
         self.registers[r1] = result
 
-        self.flags["C"] = False
+        self.flags.C = False
         self.set_flags(result)
-        self.flags["A"] = False
+        self.flags.A = False
 
         self.cycles += 4
 
@@ -810,7 +798,7 @@ class Intel8080(CPU):
         result = value1 & value2
         self.registers[r1] = result
 
-        self.flags["C"] = False
+        self.flags.C = False
         self.set_flags(result)
         self.set_aux_carry_flag(value1, value2)
 
@@ -818,13 +806,13 @@ class Intel8080(CPU):
 
     @manager.add_instruction(OPCodes.STC)
     def set_carry(self):
-        self.flags["C"] = True
+        self.flags.C = True
 
         self.cycles += 4
 
     @manager.add_instruction(OPCodes.RZ)
     def return_if_zero(self) -> None:
-        if self.flags["Z"]:
+        if self.flags.Z:
             h, l = self.pop()
             self.PC = join_bytes(h, l)
             self.cycles += 11
@@ -834,7 +822,7 @@ class Intel8080(CPU):
 
     @manager.add_instruction(OPCodes.RNZ)
     def return_if_not_zero(self) -> None:
-        if not self.flags["Z"]:
+        if not self.flags.Z:
             h, l = self.pop()
             self.PC = join_bytes(h, l)
             self.cycles += 11
@@ -875,14 +863,14 @@ class Intel8080(CPU):
 
         self.set_flags(new_value)
         lsb = result & 0xF
-        self.flags["A"] = lsb > 0xF
+        self.flags.A = lsb > 0xF
 
         self.cycles += 10
 
     @manager.add_instruction(OPCodes.CZ)
     def call_if_zero(self) -> None:
         address = self.fetch_word()
-        if self.flags["Z"]:
+        if self.flags.Z:
             h, l = split_word(self.PC)
             self.push(h, l)
             self.PC = address
@@ -894,7 +882,7 @@ class Intel8080(CPU):
     @manager.add_instruction(OPCodes.CNZ)
     def call_if_not_zero(self) -> None:
         address = self.fetch_word()
-        if not self.flags["Z"]:
+        if not self.flags.Z:
             h, l = split_word(self.PC)
             self.push(h, l)
             self.PC = address
@@ -935,13 +923,13 @@ class Intel8080(CPU):
         x = (i_value ^ 0xFF) + 0x01
 
         c = ((x & 0xF) + (a_value & 0xF)) > 0xF
-        self.flags["A"] = c
+        self.flags.A = c
 
         self.cycles += 7
 
     @manager.add_instruction(OPCodes.SBI)
     def substract_immdiate_from_accumulator_with_borrow(self) -> None:
-        carry = 1 if self.flags["C"] else 0
+        carry = 1 if self.flags.C else 0
         i_value = self.fetch_byte()
         i_value += carry
         i_value &= 0xFF
@@ -958,7 +946,7 @@ class Intel8080(CPU):
         x = (i_value ^ 0xFF) + 0x01
 
         c = ((x & 0xF) + (a_value & 0xF)) > 0xF
-        self.flags["A"] = c
+        self.flags.A = c
 
         self.cycles += 7
 
@@ -977,7 +965,7 @@ class Intel8080(CPU):
 
     @manager.add_instruction(OPCodes.RM)
     def return_if_minus(self) -> None:
-        if self.flags["S"]:
+        if self.flags.S:
             h, l = self.pop()
             self.PC = join_bytes(h, l)
             self.cycles += 11
@@ -1004,7 +992,7 @@ class Intel8080(CPU):
     @manager.add_instruction(OPCodes.CPE)
     def call_if_parity_even(self) -> None:
         address = self.fetch_word()
-        if self.flags["P"]:
+        if self.flags.P:
             h, l = split_word(self.PC)
             self.push(h, l)
             self.PC = address
@@ -1015,7 +1003,7 @@ class Intel8080(CPU):
 
     @manager.add_instruction(OPCodes.RP)
     def return_if_parity_even(self) -> None:
-        if self.flags["P"]:
+        if self.flags.P:
             h, l = self.pop()
             self.PC = join_bytes(h, l)
             self.cycles += 11
@@ -1059,7 +1047,7 @@ class Intel8080(CPU):
 
         self.set_flags(result)
         self.set_aux_carry_flag(value1, value2)
-        self.flags["C"] = False
+        self.flags.C = False
 
         self.cycles += 7
 
@@ -1080,7 +1068,7 @@ class Intel8080(CPU):
         self.set_flags(new_value)
 
         lsb = value & 0xF
-        self.flags["A"] = (lsb + 1) > 0xF
+        self.flags.A = (lsb + 1) > 0xF
 
         self.cycles += 10
 
@@ -1096,17 +1084,17 @@ class Intel8080(CPU):
 
         self.set_flags(result & 0xFF)
         self.set_carry_flag(result)
-        self.flags["P"] = (bin(r).count("1") % 2) == 0
+        self.flags.P = (bin(r).count("1") % 2) == 0
         lsb_a = a_value & 0xF
         lsb_i = tc_val & 0xF
-        self.flags["A"] = (lsb_a + lsb_i) > 0xF
+        self.flags.A = (lsb_a + lsb_i) > 0xF
 
         self.cycles += 4
 
     @manager.add_instruction(OPCodes.CNC)
     def call_if_not_carry(self):
         address = self.fetch_word()
-        if not self.flags["C"]:
+        if not self.flags.C:
             h, l = split_word(self.PC)
             self.push(h, l)
             self.PC = address
@@ -1128,10 +1116,10 @@ class Intel8080(CPU):
 
         self.set_flags(result & 0xFF)
         self.set_carry_flag(result)
-        self.flags["P"] = (bin(r).count("1") % 2) == 0
+        self.flags.P = (bin(r).count("1") % 2) == 0
         lsb_a = a_value & 0xF
         lsb_i = tc_val & 0xF
-        self.flags["A"] = (lsb_a + lsb_i) > 0xF
+        self.flags.A = (lsb_a + lsb_i) > 0xF
 
         self.cycles += 7
 
@@ -1151,6 +1139,6 @@ class Intel8080(CPU):
         lsb_1 = twos_complement & 0xF
         lsb_2 = a_value & 0xF
         ac = (lsb_1 + lsb_2) > 0xF
-        self.flags["A"] = ac
+        self.flags.A = ac
 
         self.cycles += 4

--- a/xpire/cpus/intel_8080.py
+++ b/xpire/cpus/intel_8080.py
@@ -922,7 +922,7 @@ class Intel8080(CPU):
         self.cycles += 7
 
     @manager.add_instruction(OPCodes.SBI)
-    def substract_immdiate_from_accumulator_with_borrow(self) -> None:
+    def substract_immediate_from_accumulator_with_borrow(self) -> None:
         carry = 1 if self.flags.C else 0
         i_value = self.fetch_byte()
         i_value += carry

--- a/xpire/cpus/intel_8080.py
+++ b/xpire/cpus/intel_8080.py
@@ -34,12 +34,6 @@ class Intel8080(CPU):
 
         self.out = {}
 
-        # self.flags["Z"] = False  # Zero flag
-        # self.flags["S"] = False  # Sign flag
-        # self.flags["P"] = False  # Parity flag
-        # self.flags["C"] = False  # Carry flag
-        # self.flags["A"] = False  # Aux carry flag
-
         self.interrupts_enabled = False
 
     def write_memory_byte(self, address, value) -> None:

--- a/xpire/flags.py
+++ b/xpire/flags.py
@@ -1,0 +1,130 @@
+"""
+Flags module for the CPU emulator.
+
+This module defines the FlagsManager class, which represents the flags
+of the CPU emulator.
+"""
+
+
+class FlagsManager:
+    """
+    FlagsManager class for the CPU emulator.
+    """
+
+    _flags: int
+
+    def __init__(self):
+        """
+        Initialize a new FlagsManager object.
+
+        Flags are stored in a 8-bit integer, with the following bits:
+            S	Z	0	AC	0	P	1	C
+
+        S: Sign flag
+        Z: Zero flag
+        AC: Aux carry flag
+        P: Parity flag
+        C: Carry flag
+        """
+        self._flags = 0x02  # Second bit is always set
+
+    def get_flags(self):
+        """
+        Get the flags as a 8-bit integer.
+
+        Returns:
+            int: The flags as a 8-bit integer.
+        """
+        return self._flags
+
+    def set_flags(self, flags: int):
+        """
+        Set the flags to the given value.
+
+        Args:
+            flags (int): The value to set the flags to.
+
+        Returns:
+            None
+        """
+        self._flags = flags
+
+    def add_flag(self, flag: int):
+        """
+        Add a specific flag to the flags.
+
+        Args:
+            flag (int): The flag to add.
+
+        Returns:
+            None
+        """
+        self._flags |= flag
+
+    def remove_flag(self, flag: int):
+        """
+        Remove a specific flag from the flags.
+
+        Args:
+            flag (int): The flag to remove.
+
+        Returns:
+            None
+        """
+        self._flags &= ~flag
+
+    def check_flag(self, flag: int):
+        """
+        Check if a specific flag is set.
+
+        Args:
+            flag (int): The flag to check.
+
+        Returns:
+            bool: True if the flag is set, False otherwise.
+        """
+
+        return bool(self._flags & flag)
+
+    def set_flag(self, flag: int, value: bool):
+        self.add_flag(flag) if value else self.remove_flag(flag)
+
+    @property
+    def C(self) -> bool:
+        return self.check_flag(0x01)
+
+    @C.setter
+    def C(self, value: bool) -> None:
+        self.set_flag(0x01, value)
+
+    @property
+    def P(self) -> bool:
+        return self.check_flag(0x04)
+
+    @P.setter
+    def P(self, value: bool) -> None:
+        self.set_flag(0x04, value)
+
+    @property
+    def A(self) -> bool:
+        return self.check_flag(0x10)
+
+    @A.setter
+    def A(self, value: bool) -> None:
+        self.set_flag(0x10, value)
+
+    @property
+    def Z(self) -> bool:
+        return self.check_flag(0x40)
+
+    @Z.setter
+    def Z(self, value: bool) -> None:
+        self.set_flag(0x40, value)
+
+    @property
+    def S(self) -> bool:
+        return self.check_flag(0x80)
+
+    @S.setter
+    def S(self, value: bool) -> None:
+        self.set_flag(0x80, value)

--- a/xpire/flags.py
+++ b/xpire/flags.py
@@ -26,7 +26,7 @@ class FlagsManager:
         P: Parity flag
         C: Carry flag
         """
-        self._flags = 0x02  # Second bit is always set
+        self.clear_flags()
 
     def get_flags(self):
         """
@@ -47,7 +47,7 @@ class FlagsManager:
         Returns:
             None
         """
-        self._flags = flags
+        self._flags = flags | 0x02  # Second bit is always set
 
     def add_flag(self, flag: int):
         """
@@ -85,6 +85,16 @@ class FlagsManager:
         """
 
         return bool(self._flags & flag)
+
+    def clear_flags(self):
+        """
+        Clear all flags except the second bit.
+
+        This method resets the flags to their default state with only the
+        second bit set, effectively clearing all other flags.
+        """
+
+        self._flags = 0x02  # Second bit is always set
 
     def set_flag(self, flag: int, value: bool):
         self.add_flag(flag) if value else self.remove_flag(flag)


### PR DESCRIPTION
<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR refactors the flag handling in the CPU emulator to use a dedicated `FlagsManager` class, improving modularity and readability.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant CPU as Intel8080 CPU
    participant FM as FlagsManager
    participant Reg as Registers

    Note over CPU,FM: Initialization
    CPU->>FM: create FlagsManager()
    FM->>FM: clear_flags()
    
    Note over CPU,FM: Flag Operations
    CPU->>FM: set_flags(value)
    CPU->>FM: set_carry_flag(value)
    CPU->>FM: set_aux_carry_flag(a, b)
    
    Note over CPU,Reg: Register Operations with Flags
    CPU->>Reg: read/write registers
    CPU->>FM: update flags (Z, S, P, C, A)
    
    Note over CPU,FM: Flag Checks for Control Flow
    CPU->>FM: check Z flag
    FM-->>CPU: flag status
    CPU->>CPU: conditional jump/return
    
    Note over CPU,FM: Flag State Management
    CPU->>FM: get_flags()
    FM-->>CPU: current flags
    CPU->>FM: set_flags(new_flags)
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/JorgeJuarezM/xpire/pull/23/files#diff-858c63abde64d01be5792d751da8d8c5d0d4ec40ad2c24cfc4a2fc16303779c3>tests/test_intel_8080.py</a></td><td>Refactored tests to access flags using dot notation instead of dictionary-style access.</td></tr>
<tr><td><a href=https://github.com/JorgeJuarezM/xpire/pull/23/files#diff-72dcbc6a396c9ef564cfc4e41663c437f4c56106930914f124e27e973d824c1e>xpire/cpus/cpu.py</a></td><td>Initialized <code>FlagsManager</code> in the CPU class.</td></tr>
<tr><td><a href=https://github.com/JorgeJuarezM/xpire/pull/23/files#diff-791bf21915b24ec4d37d2698d8e8ce62c5a233d88d3729a8aa63c051bee9e44c>xpire/cpus/intel_8080.py</a></td><td>Updated flag handling to use the <code>FlagsManager</code> class.</td></tr>
<tr><td><a href=https://github.com/JorgeJuarezM/xpire/pull/23/files#diff-9d4e08ead9c13d650e40233ed5921ef18abbfc615e85b2b94186b2e202a6156f>xpire/flags.py</a></td><td>Added <code>FlagsManager</code> class to manage CPU flags.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


















