### PR TITLE
feat: add more opcodes

### DIFF
--- a/tests/test_intel_8080.py
+++ b/tests/test_intel_8080.py
@@ -121,7 +121,7 @@ class TestIntel8080(unittest.TestCase):
     def test_register_and_register(self):
         self.cpu.registers[Registers.A] = 0xFC
         self.cpu.registers[Registers.D] = 0x0F
-        self.cpu.register_and_register(Registers.A, Registers.D)
+        self.cpu.ana_reg(Registers.D)
 
         self.assertEqual(self.cpu.registers[Registers.A], 0x0C)
         self.assertEqual(self.cpu.flags.S, False)
@@ -134,7 +134,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.registers[Registers.B] = 0x0F
         self.cpu.registers[Registers.C] = 0x0F
 
-        self.cpu.apply_xor_to_registers(Registers.A, Registers.A)
+        self.cpu.xra(Registers.A)
         self.cpu.mov_reg_reg(Registers.A, Registers.B)
         self.cpu.mov_reg_reg(Registers.A, Registers.C)
 
@@ -152,7 +152,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.registers[Registers.A] = 0b11111111  # 0xFF
         self.cpu.registers[Registers.B] = 0b10111011  # 0xBB
 
-        self.cpu.apply_xor_to_registers(Registers.A, Registers.B)
+        self.cpu.xra(Registers.B)
 
         self.assertEqual(self.cpu.registers[Registers.A], 0b01000100)  # 0x44
         self.assertEqual(self.cpu.registers[Registers.B], 0b10111011)  # 0xBB

--- a/xpire/cpus/intel_8080.py
+++ b/xpire/cpus/intel_8080.py
@@ -827,13 +827,9 @@ class Intel8080(CPU):
         result = a_value & value2
         self.registers[Registers.A] = result
 
-        # print(result, result & 0x80)
-
         self.flags.S = (result & 0x80) != 0
-        # self.flags.S = (result & (0xFF - (0xFF >> 1))) != 0
         self.flags.Z = (result & 0xFF) == 0
         self.flags.P = bin(result & 0xFF).count("1") % 2 == 0
-        # self.flags.A = False
         self.flags.C = False
         self.flags.A = (get_ls_nib(a_value) + get_ls_nib(value2)) > 0xF
 
@@ -1456,8 +1452,6 @@ class Intel8080(CPU):
     def jpo(self) -> None:
         address = self.fetch_word()
         if not self.flags.P:
-            # h, l = split_word(self.PC)
-            # self.push(h, l)
             self.PC = address
             self.cycles += 17
             return


### PR DESCRIPTION
<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds new opcodes and their corresponding methods to the Intel 8080 CPU implementation, including XOR and AND operations with registers and memory.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant CPU as Intel 8080 CPU
    participant Registers
    participant Memory
    participant Flags

    Note over CPU: New Instructions Added
    
    rect rgb(200, 200, 255)
        CPU->>Registers: XRA (Exclusive OR with Accumulator)
        CPU->>Flags: Update S,Z,P flags
    end
    
    rect rgb(200, 255, 200)
        CPU->>Registers: ANA (AND with Accumulator)
        CPU->>Flags: Update S,Z,P,A flags
    end
    
    rect rgb(255, 200, 200)
        CPU->>Memory: Memory Operations (SBB, ADC)
        Memory-->>CPU: Read memory value
        CPU->>Registers: Update Accumulator
        CPU->>Flags: Update status flags
    end
    
    rect rgb(255, 255, 200)
        Note over CPU: RST (Restart) Instructions
        CPU->>CPU: Check interrupts_enabled
        CPU->>Memory: Push PC to stack
        CPU->>CPU: Set new PC value
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/JorgeJuarezM/xpire/pull/31/files#diff-858c63abde64d01be5792d751da8d8c5d0d4ec40ad2c24cfc4a2fc16303779c3>tests/test_intel_8080.py</a></td><td>Updated tests to use new opcode methods for register operations.</td></tr>
<tr><td><a href=https://github.com/JorgeJuarezM/xpire/pull/31/files#diff-791bf21915b24ec4d37d2698d8e8ce62c5a233d88d3729a8aa63c051bee9e44c>xpire/cpus/intel_8080.py</a></td><td>Added new opcode methods for XOR and AND operations, and modified existing methods to use these new opcodes.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->






