### PR TITLE
feat: re-order opcodes

### DIFF
--- a/tests/test_intel_8080.py
+++ b/tests/test_intel_8080.py
@@ -87,7 +87,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.flags.A = False
 
         self.cpu.registers[Registers.B] = 0xFE
-        self.cpu.increment_register(Registers.B)
+        self.cpu.inr_reg(Registers.B)
 
         self.assertEqual(self.cpu.registers[Registers.B], 0xFF)
         self.assertEqual(self.cpu.flags.Z, False)
@@ -97,7 +97,7 @@ class TestIntel8080(unittest.TestCase):
         self.assertEqual(self.cpu.flags.A, False)
 
         self.cpu.registers[Registers.B] = 0xFF
-        self.cpu.increment_register(Registers.B)
+        self.cpu.inr_reg(Registers.B)
 
         self.assertEqual(self.cpu.registers[Registers.B], 0x00)
         self.assertEqual(self.cpu.flags.Z, True)
@@ -186,7 +186,7 @@ class TestIntel8080(unittest.TestCase):
             0b11110010 -> 0b01111001
         """
         self.cpu.registers[Registers.A] = 0b11110010  # 0xF2
-        self.cpu.rotate_right_a()
+        self.cpu.rrc()
 
         self.assertEqual(self.cpu.registers[Registers.A], 0b1111001)  # 0x79
         self.assertEqual(self.cpu.flags.S, False)
@@ -199,7 +199,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.registers[Registers.A] = 0b01101010  # 0x6A
         self.cpu.flags.C = True
 
-        self.cpu.rotate_right_a_through_carry()
+        self.cpu.rar()
 
         self.assertEqual(self.cpu.registers[Registers.A], 0b10110101)  # 0xB5
         self.assertEqual(self.cpu.flags.S, False)
@@ -215,7 +215,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.registers[Registers.H] = 0xA1
         self.cpu.registers[Registers.L] = 0x7B
 
-        self.cpu.sum_register_pair_with_hl(Registers.B, Registers.C)
+        self.cpu.dad_reg16(Registers.B, Registers.C)
 
         self.assertEqual(self.cpu.registers[Registers.H], 0xD5)
         self.assertEqual(self.cpu.registers[Registers.L], 0x1A)
@@ -232,9 +232,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.registers[Registers.D] = 0x33
         self.cpu.registers[Registers.E] = 0x55
 
-        self.cpu.exchange_register_pairs(
-            Registers.H, Registers.L, Registers.D, Registers.E
-        )
+        self.cpu.xchg(Registers.H, Registers.L, Registers.D, Registers.E)
 
         self.assertEqual(self.cpu.registers[Registers.H], 0x33)
         self.assertEqual(self.cpu.registers[Registers.L], 0x55)
@@ -247,10 +245,10 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.add_immediate_to_accumulator()
+        self.cpu.adi_d8()
         self.assertEqual(self.cpu.registers[Registers.A], 0x56)
 
-        self.cpu.add_immediate_to_accumulator()
+        self.cpu.adi_d8()
         self.assertEqual(self.cpu.registers[Registers.A], 0x14)
         self.assertEqual(self.cpu.flags.S, False)
         self.assertEqual(self.cpu.flags.Z, False)
@@ -291,7 +289,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.registers[Registers.H] = 0x00
         self.cpu.registers[Registers.L] = 0xFF
 
-        self.cpu.push_to_stack(Registers.H, Registers.L)
+        self.cpu.push(Registers.H, Registers.L)
 
         self.assertEqual(self.cpu.memory[self.cpu.SP], 0xFF)
         self.assertEqual(self.cpu.memory[self.cpu.SP - 1], 0x00)
@@ -322,7 +320,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[self.cpu.SP] = 0xDD
         self.cpu.memory[self.cpu.SP + 1] = 0xDE
 
-        self.cpu.exchange_sp_hl()
+        self.cpu.xthl()
 
         self.assertEqual(self.cpu.registers[Registers.H], 0xDE)  # SP +1
         self.assertEqual(self.cpu.registers[Registers.L], 0xDD)  # SP
@@ -334,7 +332,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.registers[Registers.L] = 0x00
         self.cpu.memory[0x0000] = 0x19
 
-        self.cpu.increment_memory_address()
+        self.cpu.inr_m()
 
         self.assertEqual(self.cpu.memory[0x0000], 0x1A)
         self.assertEqual(self.cpu.flags.S, False)
@@ -348,7 +346,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.PC = 0x0000
         self.cpu.memory[0x0000] = 0x42
 
-        self.cpu.accumulator_and_immediate()
+        self.cpu.ani_d8()
 
         self.assertEqual(self.cpu.registers[Registers.A], 0x00)
         self.assertEqual(self.cpu.flags.S, False)
@@ -364,7 +362,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.jump_if_minus()
+        self.cpu.jm_addr()
 
         self.assertEqual(self.cpu.PC, 0xBE42)
 
@@ -375,7 +373,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.jump_if_minus()
+        self.cpu.jm_addr()
 
         self.assertEqual(self.cpu.PC, 0x0002)  # PC + 2 (fetch word)
 
@@ -384,7 +382,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.PC = 0x0000
         self.cpu.memory[0x0000] = 0x42
 
-        self.cpu.substract_immediate_from_accumulator()
+        self.cpu.sui_d8()
 
         self.assertEqual(self.cpu.registers[Registers.A], 0xD2)
         self.assertEqual(self.cpu.flags.S, True)
@@ -434,7 +432,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.call_if_not_carry()
+        self.cpu.cnc_addr()
 
         self.assertEqual(self.cpu.PC, 0xBE42)
         self.assertEqual(self.cpu.SP, 0xFFFE)
@@ -447,7 +445,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.call_if_not_carry()
+        self.cpu.cnc_addr()
 
         self.assertEqual(self.cpu.PC, 0x0002)
         self.assertEqual(self.cpu.SP, 0x0000)
@@ -483,7 +481,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.PC = 0x0000
         self.cpu.memory[0x0000] = 0x42
 
-        self.cpu.compare_register_with_memory()
+        self.cpu.cmp_m()
 
         self.assertEqual(self.cpu.flags.S, True)
         self.assertEqual(self.cpu.flags.Z, False)
@@ -534,7 +532,7 @@ class TestIntel8080(unittest.TestCase):
 
     def test_decrement_register(self):
         self.cpu.registers[Registers.A] = 0x14
-        self.cpu.decrement_register(Registers.A)
+        self.cpu.dcr_reg(Registers.A)
 
         self.assertEqual(self.cpu.registers[Registers.A], 0x13)
         self.assertEqual(self.cpu.flags.S, False)
@@ -550,7 +548,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.jump_if_not_zero()
+        self.cpu.jnz_addr()
 
         self.assertEqual(self.cpu.PC, 0xBE42)
 
@@ -558,7 +556,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.flags.clear_flags()
         self.cpu.flags.Z = True
 
-        self.cpu.jump_if_not_zero()
+        self.cpu.jnz_addr()
 
         self.assertEqual(self.cpu.PC, 0x0002)
 
@@ -586,7 +584,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.return_if_not_carry()
+        self.cpu.rnc()
 
         self.assertEqual(self.cpu.PC, 0xBE42)
         self.assertEqual(self.cpu.SP, 0x0002)
@@ -599,7 +597,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.return_if_not_carry()
+        self.cpu.rnc()
 
         self.assertEqual(self.cpu.PC, 0x0000)
         self.assertEqual(self.cpu.SP, 0x0000)
@@ -612,7 +610,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.return_if_carry()
+        self.cpu.rc()
 
         self.assertEqual(self.cpu.PC, 0xBE42)
         self.assertEqual(self.cpu.SP, 0x0002)
@@ -625,7 +623,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.return_if_carry()
+        self.cpu.rc()
 
         self.assertEqual(self.cpu.PC, 0x0000)
         self.assertEqual(self.cpu.SP, 0x0000)
@@ -638,7 +636,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.registers[Registers.H] = 0x00
         self.cpu.registers[Registers.L] = 0x00
 
-        self.cpu.register_or_with_memory(Registers.A)
+        self.cpu.ora_m(Registers.A)
 
         self.assertEqual(self.cpu.registers[Registers.A], 0x14)
         self.assertEqual(self.cpu.flags.S, False)
@@ -654,7 +652,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.jump_if_zero()
+        self.cpu.jz_addr()
 
         self.assertEqual(self.cpu.PC, 0xBE42)
 
@@ -662,7 +660,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.flags.clear_flags()
         self.cpu.flags.Z = False
 
-        self.cpu.jump_if_zero()
+        self.cpu.jz_addr()
 
         self.assertEqual(self.cpu.PC, 0x0002)
 
@@ -673,7 +671,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.jump_if_parity()
+        self.cpu.jpe_addr()
 
         self.assertEqual(self.cpu.PC, 0xBE42)
 
@@ -681,13 +679,13 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.flags.clear_flags()
         self.cpu.flags.P = False
 
-        self.cpu.jump_if_parity()
+        self.cpu.jpe_addr()
 
         self.assertEqual(self.cpu.PC, 0x0002)
 
     def test_rotate_left_accumulator(self):
         self.cpu.registers[Registers.A] = 0x14
-        self.cpu.rotate_left_accumulator()
+        self.cpu.rlc()
 
         self.assertEqual(self.cpu.registers[Registers.A], 0x28)
         self.assertEqual(self.cpu.flags.S, False)
@@ -703,7 +701,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.jump_if_not_carry()
+        self.cpu.jnc_addr()
 
         self.assertEqual(self.cpu.PC, 0xBE42)
 
@@ -711,7 +709,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.flags.clear_flags()
         self.cpu.flags.C = True
 
-        self.cpu.jump_if_not_carry()
+        self.cpu.jnc_addr()
 
         self.assertEqual(self.cpu.PC, 0x0002)
 
@@ -722,7 +720,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.jump_if_carry()
+        self.cpu.jc_addr()
 
         self.assertEqual(self.cpu.PC, 0xBE42)
 
@@ -730,7 +728,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.flags.clear_flags()
         self.cpu.flags.C = False
 
-        self.cpu.jump_if_carry()
+        self.cpu.jc_addr()
 
         self.assertEqual(self.cpu.PC, 0x0002)
 
@@ -740,11 +738,11 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.registers[Registers.A] = 0x14
         self.cpu.flags.set_flags(0xFF)
 
-        self.cpu.push_processor_state_word()
+        self.cpu.push_psw()
         self.cpu.registers[Registers.A] = 0x20
         self.cpu.flags.clear_flags()
 
-        self.cpu.pop_processor_state_word()
+        self.cpu.pop_psw()
 
         self.assertEqual(self.cpu.PC, 0x0000)
         self.assertEqual(self.cpu.SP, 0x0000)
@@ -767,7 +765,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.return_if_zero()
+        self.cpu.rz()
 
         self.assertEqual(self.cpu.PC, 0xBE42)
         self.assertEqual(self.cpu.SP, 0x0002)
@@ -780,7 +778,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.return_if_zero()
+        self.cpu.rz()
 
         self.assertEqual(self.cpu.PC, 0x0000)
         self.assertEqual(self.cpu.SP, 0x0000)
@@ -793,7 +791,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.return_if_not_zero()
+        self.cpu.rnz()
 
         self.assertEqual(self.cpu.PC, 0xBE42)
         self.assertEqual(self.cpu.SP, 0x0002)
@@ -806,14 +804,14 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.return_if_not_zero()
+        self.cpu.rnz()
 
         self.assertEqual(self.cpu.PC, 0x0000)
         self.assertEqual(self.cpu.SP, 0x0000)
 
     def test_decrement_memory_byte(self):
         self.cpu.memory[0x0000] = 0x14
-        self.cpu.decrement_memory_byte()
+        self.cpu.dcr_m()
 
         self.assertEqual(self.cpu.memory[0x0000], 0x13)
         self.assertEqual(self.cpu.flags.S, False)
@@ -830,7 +828,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.call_if_zero()
+        self.cpu.cz_addr()
 
         self.assertEqual(self.cpu.PC, 0xBE42)
         self.assertEqual(self.cpu.SP, 0xFFFE)
@@ -843,7 +841,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.call_if_zero()
+        self.cpu.cz_addr()
 
         self.assertEqual(self.cpu.PC, 0x0002)
         self.assertEqual(self.cpu.SP, 0x0000)
@@ -856,7 +854,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.call_if_not_zero()
+        self.cpu.cnz_addr()
 
         self.assertEqual(self.cpu.PC, 0xBE42)
         self.assertEqual(self.cpu.SP, 0xFFFE)
@@ -869,7 +867,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.call_if_not_zero()
+        self.cpu.cnz_addr()
 
         self.assertEqual(self.cpu.PC, 0x0002)
         self.assertEqual(self.cpu.SP, 0x0000)
@@ -877,7 +875,7 @@ class TestIntel8080(unittest.TestCase):
     def test_substract_immdiate_from_accumulator_with_borrow(self):
         self.cpu.registers[Registers.A] = 0x14
         self.cpu.memory[0x0000] = 0x21
-        self.cpu.substract_immediate_from_accumulator_with_borrow()
+        self.cpu.sbi_d8()
 
         self.assertEqual(self.cpu.registers[Registers.A], 0xF3)
         self.assertEqual(self.cpu.flags.S, True)
@@ -894,7 +892,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.return_if_minus()
+        self.cpu.rm()
 
         self.assertEqual(self.cpu.PC, 0xBE42)
         self.assertEqual(self.cpu.SP, 0x0002)
@@ -907,7 +905,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.return_if_minus()
+        self.cpu.rm()
 
         self.assertEqual(self.cpu.PC, 0x0000)
         self.assertEqual(self.cpu.SP, 0x0000)
@@ -920,7 +918,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.return_if_parity_even()
+        self.cpu.rp()
 
         self.assertEqual(self.cpu.PC, 0xBE42)
         self.assertEqual(self.cpu.SP, 0x0002)
@@ -933,7 +931,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.return_if_parity_even()
+        self.cpu.rp()
 
         self.assertEqual(self.cpu.PC, 0x0000)
         self.assertEqual(self.cpu.SP, 0x0000)
@@ -946,7 +944,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.call_if_parity_even()
+        self.cpu.cpe_addr()
 
         self.assertEqual(self.cpu.PC, 0xBE42)
         self.assertEqual(self.cpu.SP, 0xFFFE)
@@ -959,7 +957,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.memory[0x0000] = 0x42
         self.cpu.memory[0x0001] = 0xBE
 
-        self.cpu.call_if_parity_even()
+        self.cpu.cpe_addr()
 
         self.assertEqual(self.cpu.PC, 0x02)
         self.assertEqual(self.cpu.SP, 0x0000)
@@ -988,7 +986,7 @@ class TestIntel8080(unittest.TestCase):
         self.cpu.registers[Registers.A] = 0x00
         self.cpu.port_1 = 0xFF
         self.cpu.memory[0x0000] = 0x01  # PORT 1
-        self.cpu.input()
+        self.cpu.in_d8()
         self.assertEqual(self.cpu.registers[Registers.A], 0xFF)
 
     def test_stax_reg(self):

--- a/xpire/cpus/intel_8080.py
+++ b/xpire/cpus/intel_8080.py
@@ -1205,7 +1205,7 @@ class Intel8080(CPU):
     @manager.add_instruction(0xE2)
     def jpo_addr(self) -> None:
         address = self.fetch_word()
-        if not self.flags.P:
+        if self.flags.P:
             self.PC = address
             self.cycles += 17
             return

--- a/xpire/cpus/intel_8080.py
+++ b/xpire/cpus/intel_8080.py
@@ -2,7 +2,6 @@
 Intel 8080 CPU implementation.
 """
 
-import xpire.instructions.intel_8080 as OPCodes
 from xpire.cpus.cpu import CPU
 from xpire.decorators import increment_stack_pointer
 from xpire.instructions.manager import InstructionManager as manager
@@ -46,7 +45,7 @@ class Intel8080(CPU):
         address = address & 0xFFFF
         self.memory[address] = value & 0xFF
 
-    def push(self, high_byte, low_byte) -> None:
+    def _push(self, high_byte, low_byte) -> None:
         """
         Push a word to the stack.
 
@@ -72,7 +71,7 @@ class Intel8080(CPU):
         self.write_memory_byte(address + 0x01, high_byte)
 
     @increment_stack_pointer()
-    def pop(self) -> tuple[int, int]:
+    def _pop(self) -> tuple[int, int]:
         """
         Pop a 16-bit value from the stack.
 
@@ -130,146 +129,47 @@ class Intel8080(CPU):
         self.flags.P = (bin(result & 0xFF).count("1") % 2) == 0
         self.flags.C = result <= 0xFF
 
-    @manager.add_instruction(OPCodes.LDA)
-    def load_memory_address_to_accumulator(self) -> None:
-        """
-        Load the value at the specified memory address to the accumulator (A register).
-
-        This instruction fetches a 16-bit address from memory and loads the value stored at that address
-        to the accumulator. The value is loaded as a byte, not a word.
-        """
-        address = self.fetch_word()
-        value = self.read_memory_byte(address)
-        self.registers[Registers.A] = value
-        self.cycles += 13
-
-    @manager.add_instruction(OPCodes.JMP)
-    def jump_to_address(self) -> None:
-        """
-        Jump to the specified address.
-
-        This instruction fetches a 16-bit address from memory and sets the
-        program counter (PC) to that address, effectively jumping to the
-        instruction at that location.
-        """
-        address = self.fetch_word()
-        self.PC = address
+    @manager.add_instruction(0x01, [Registers.B, Registers.C])
+    @manager.add_instruction(0x11, [Registers.D, Registers.E])
+    @manager.add_instruction(0x21, [Registers.H, Registers.L])
+    def lxi_reg_d16(self, h: int, l: int) -> None:
+        self.registers[l] = self.fetch_byte()
+        self.registers[h] = self.fetch_byte()
         self.cycles += 10
 
-    @manager.add_instruction(OPCodes.LXI_SP)
-    def load_immediate_to_stack_pointer(self) -> None:
-        """
-        Load a 16-bit address from memory to the stack pointer (SP).
-
-        The stack pointer is set to the value of the 16-bit address fetched from memory.
-        """
-        self.SP = self.fetch_word()
-        self.cycles += 10
-
-    @manager.add_instruction(OPCodes.CALL)
-    def call_address(self) -> None:
-        """
-        Call the subroutine at the specified address.
-
-        This function fetches a 16-bit address from memory and sets the program counter (PC)
-        to that address, effectively jumping to the subroutine at that location. Before jumping,
-        it pushes the current PC onto the stack to allow returning to the original location after
-        the subroutine completes.
-
-        The fetch_word method is used to retrieve the 16-bit address from memory, and the current PC
-        is split into high and low bytes and pushed onto the stack.
-        """
-
-        address_to_jump = self.fetch_word()
-        h, l = split_word(self.PC)
-        self.push(h, l)
-        self.PC = address_to_jump
-        self.cycles += 17
-
-    @manager.add_instruction(OPCodes.RET)
-    def return_from_call(self) -> None:
-        """
-        Return from a subroutine call by restoring the program counter.
-
-        This method pops two bytes from the stack and uses them to
-        restore the program counter (PC) to the address from which
-        the subroutine was called. The high byte is popped first,
-        followed by the low byte, and they are combined to form the
-        complete address.
-        """
-        h, l = self.pop()
-        self.PC = h << 0x08 | l & 0xFF
-        self.cycles += 10
-
-    @manager.add_instruction(OPCodes.PUSH_BC, [Registers.B, Registers.C])
-    @manager.add_instruction(OPCodes.PUSH_DE, [Registers.D, Registers.E])
-    @manager.add_instruction(OPCodes.PUSH_HL, [Registers.H, Registers.L])
-    def push_to_stack(self, h: int, l: int) -> None:
-        """
-        Push the contents of the BC register pair onto the stack.
-
-        This method pushes the values stored in the B and C registers onto the stack.
-        The value in the C register is pushed first as the low byte, followed by the
-        value in the B register as the high byte.
-        """
-        self.push(self.registers[h], self.registers[l])
-        self.cycles += 11
-
-    @manager.add_instruction(OPCodes.POP_BC, [Registers.B, Registers.C])
-    @manager.add_instruction(OPCodes.POP_DE, [Registers.D, Registers.E])
-    @manager.add_instruction(OPCodes.POP_HL, [Registers.H, Registers.L])
-    def pop_from_stack(self, h: int, l: int) -> None:
-        """
-        Pop two bytes from the stack and store them in the specified registers pair.
-        The stack pointer is incremented by two after the pop.
-        """
-        high, low = self.pop()
-        self.registers[h], self.registers[l] = high, low
-        self.cycles += 10
-
-    @manager.add_instruction(OPCodes.STA)
-    def store_accumulator_to_memory(self) -> None:
-        """
-        Store the value of the accumulator in memory at the address specified by the next two bytes.
-
-        This instruction fetches a 16-bit address from memory and stores the value of the accumulator at that
-        address. The address is fetched as a 16-bit value from memory and the accumulator is stored in memory
-        as a byte at that address.
-        """
-        address = self.fetch_word()
+    @manager.add_instruction(0x02, [Registers.B, Registers.C])
+    @manager.add_instruction(0x12, [Registers.D, Registers.E])
+    def stax_reg(self, r1: int, r2: int):
+        address = join_bytes(self.registers[r1], self.registers[r2])
         self.write_memory_byte(address, self.registers[Registers.A])
-        self.cycles += 13
-
-    @manager.add_instruction(OPCodes.MVI_A, [Registers.A])
-    @manager.add_instruction(OPCodes.MVI_B, [Registers.B])
-    @manager.add_instruction(OPCodes.MVI_C, [Registers.C])
-    @manager.add_instruction(OPCodes.MVI_D, [Registers.D])
-    @manager.add_instruction(OPCodes.MVI_E, [Registers.E])
-    @manager.add_instruction(OPCodes.MVI_H, [Registers.H])
-    @manager.add_instruction(OPCodes.MVI_L, [Registers.L])
-    def move_immediate_to_register(self, register: int) -> callable:
-        """
-        Move an immediate value to the specified register.
-
-        This instruction fetches an immediate 8-bit value from memory and stores
-        it in the specified register. The opcode determines which register the
-        value will be stored in.
-
-        Args:
-            register (int): The register identifier where the immediate value
-                            should be stored.
-        """
-        self.registers[register] = self.fetch_byte()
         self.cycles += 7
 
-    @manager.add_instruction(OPCodes.INR_A, [Registers.A])
-    @manager.add_instruction(OPCodes.INR_B, [Registers.B])
-    @manager.add_instruction(OPCodes.INR_C, [Registers.C])
-    @manager.add_instruction(OPCodes.INR_D, [Registers.D])
-    @manager.add_instruction(OPCodes.INR_E, [Registers.E])
-    @manager.add_instruction(OPCodes.INR_H, [Registers.H])
-    @manager.add_instruction(OPCodes.INR_L, [Registers.L])
-    def increment_register(self, register: int) -> None:
+    @manager.add_instruction(0x03, [Registers.B, Registers.C])
+    @manager.add_instruction(0x13, [Registers.D, Registers.E])
+    @manager.add_instruction(0x23, [Registers.H, Registers.L])
+    def inx_reg(self, h: int, l: int) -> None:
+        """
+        Increment the value of the specified register pair by one.
+
+        Condition bits affected: Zero, Sign, Parity, Auxiliary.
+        """
+        value = join_bytes(self.registers[h], self.registers[l])
+        result = value + 0x01
+        new_value = result & 0xFFFF
+
+        high, low = split_word(new_value)
+        self.registers[h] = high
+        self.registers[l] = low
+        self.cycles += 5
+
+    @manager.add_instruction(0x04, [Registers.B])
+    @manager.add_instruction(0x0C, [Registers.C])
+    @manager.add_instruction(0x14, [Registers.D])
+    @manager.add_instruction(0x1C, [Registers.E])
+    @manager.add_instruction(0x24, [Registers.H])
+    @manager.add_instruction(0x2C, [Registers.L])
+    @manager.add_instruction(0x3C, [Registers.A])
+    def inr_reg(self, register: int) -> None:
         """
         Increment the value of the specified register by one.
 
@@ -285,14 +185,14 @@ class Intel8080(CPU):
 
         self.cycles += 5
 
-    @manager.add_instruction(OPCodes.DCR_A, [Registers.A])
-    @manager.add_instruction(OPCodes.DCR_B, [Registers.B])
-    @manager.add_instruction(OPCodes.DCR_C, [Registers.C])
-    @manager.add_instruction(OPCodes.DCR_D, [Registers.D])
-    @manager.add_instruction(OPCodes.DCR_E, [Registers.E])
-    @manager.add_instruction(OPCodes.DCR_H, [Registers.H])
-    @manager.add_instruction(OPCodes.DCR_L, [Registers.L])
-    def decrement_register(self, register: int) -> None:
+    @manager.add_instruction(0x05, [Registers.B])
+    @manager.add_instruction(0x0D, [Registers.C])
+    @manager.add_instruction(0x15, [Registers.D])
+    @manager.add_instruction(0x1D, [Registers.E])
+    @manager.add_instruction(0x25, [Registers.H])
+    @manager.add_instruction(0x2D, [Registers.L])
+    @manager.add_instruction(0x3D, [Registers.A])
+    def dcr_reg(self, register: int) -> None:
         """
         Decrement the value of the specified register by one.
 
@@ -307,66 +207,314 @@ class Intel8080(CPU):
         self.flags.A = ((result & 0xF) - 1) > 0xF
         self.cycles += 5
 
-    @manager.add_instruction(OPCodes.INX_BC, [Registers.B, Registers.C])
-    @manager.add_instruction(OPCodes.INX_DE, [Registers.D, Registers.E])
-    @manager.add_instruction(OPCodes.INX_HL, [Registers.H, Registers.L])
-    def increment_register_pair(self, h: int, l: int) -> None:
+    @manager.add_instruction(0x06, [Registers.B])
+    @manager.add_instruction(0x0E, [Registers.C])
+    @manager.add_instruction(0x16, [Registers.D])
+    @manager.add_instruction(0x1E, [Registers.E])
+    @manager.add_instruction(0x26, [Registers.H])
+    @manager.add_instruction(0x2E, [Registers.L])
+    @manager.add_instruction(0x3E, [Registers.A])
+    def mvi_reg(self, register: int) -> callable:
         """
-        Increment the value of the specified register pair by one.
+        Move an immediate value to the specified register.
 
-        Condition bits affected: Zero, Sign, Parity, Auxiliary.
+        This instruction fetches an immediate 8-bit value from memory and stores
+        it in the specified register. The opcode determines which register the
+        value will be stored in.
+
+        Args:
+            register (int): The register identifier where the immediate value
+                            should be stored.
         """
-        value = join_bytes(self.registers[h], self.registers[l])
-        result = value + 0x01
+        self.registers[register] = self.fetch_byte()
+        self.cycles += 7
+
+    @manager.add_instruction(0x07)
+    def rlc(self) -> None:
+        """
+        The carry bit is set equal to the high-order bit of the accumulator.
+
+        The contents of the accumulator are rotated one bit position
+        to the left, with the high-order bit being transferred to the
+        low-order bit position of the accumulator.
+
+        Condition bits affected: Carry.
+        """
+        accumulator = self.registers[Registers.A] & 0xFF
+        # Obtener el bit menos significativo (LSB) del acumulador
+        new_carry = accumulator & 0x80
+        # Rotar el acumulador a la izquierda
+        # El bit de carry se convierte en el bit menos significativo (LSB)
+        accumulator = (accumulator << 1) | (new_carry >> 7)
+        # Asegurarse de que el acumulador siga siendo de 8 bits
+        accumulator = accumulator & 0xFF
+        self.registers[Registers.A] = accumulator
+        self.flags.C = True if new_carry else False
+        self.cycles += 4
+
+    @manager.add_instruction(0x08)
+    @manager.add_instruction(0x10)
+    def ignored_instruction(self) -> None:
+        self.cycles += 4
+
+    @manager.add_instruction(0x09, [Registers.B, Registers.C])
+    @manager.add_instruction(0x19, [Registers.D, Registers.E])
+    @manager.add_instruction(0x29, [Registers.H, Registers.L])
+    def dad_reg16(self, h: int, l: int) -> None:
+        """
+        The 16-bit number in the specified register pair is added
+        to the 16-bit number held in the Hand L registers using two's complement arithmetic.
+
+        The result replaces the contents of the Hand L registers.
+
+        Condition bits affected: Carry.
+        """
+        h_value = self.registers[h]
+        l_value = self.registers[l]
+
+        value1 = join_bytes(h_value, l_value)
+        value2 = join_bytes(self.registers[Registers.H], self.registers[Registers.L])
+
+        result = value1 + value2
         new_value = result & 0xFFFF
+        self.registers[Registers.H], self.registers[Registers.L] = split_word(new_value)
 
-        high, low = split_word(new_value)
-        self.registers[h] = high
-        self.registers[l] = low
-        self.cycles += 5
+        self.set_carry_flag(result, mask=0xFFFF)
 
-    @manager.add_instruction(OPCodes.LXI_BC, [Registers.B, Registers.C])
-    @manager.add_instruction(OPCodes.LXI_DE, [Registers.D, Registers.E])
-    @manager.add_instruction(OPCodes.LXI_HL, [Registers.H, Registers.L])
-    def load_immediate_to_registry_pair(self, h: int, l: int) -> None:
-        self.registers[l] = self.fetch_byte()
-        self.registers[h] = self.fetch_byte()
         self.cycles += 10
 
-    @manager.add_instruction(OPCodes.LDAX_BC, [Registers.B, Registers.C])
-    @manager.add_instruction(OPCodes.LDAX_DE, [Registers.D, Registers.E])
-    def load_address_from_register_to_accumulator(self, h: int, l: int) -> None:
+    @manager.add_instruction(0x0A, [Registers.B, Registers.C])
+    @manager.add_instruction(0x1A, [Registers.D, Registers.E])
+    def ldax_reg16(self, h: int, l: int) -> None:
         address_l = self.registers[l]
         address_h = self.registers[h]
         address = join_bytes(address_h, address_l)
         self.registers[Registers.A] = self.read_memory_byte(address)
         self.cycles += 7
 
-    @manager.add_instruction(0x70, [Registers.B])
-    @manager.add_instruction(0x71, [Registers.C])
-    @manager.add_instruction(0x72, [Registers.D])
-    @manager.add_instruction(0x73, [Registers.E])
-    @manager.add_instruction(0x74, [Registers.H])
-    @manager.add_instruction(0x75, [Registers.L])
-    @manager.add_instruction(0x77, [Registers.A])
-    def mov_m_reg(self, register: int) -> None:
-        address = join_bytes(self.registers[Registers.H], self.registers[Registers.L])
-        self.write_memory_byte(address, self.registers[register])
-        self.cycles += 7
+    @manager.add_instruction(0x0B, [Registers.B, Registers.C])
+    @manager.add_instruction(0x1B, [Registers.D, Registers.E])
+    @manager.add_instruction(0x2B, [Registers.H, Registers.L])
+    def dcx_reg16(self, h: int, l: int):
+        value = join_bytes(self.registers[h], self.registers[l])
+        result = value - 0x01
+        result = result & 0xFFFF
+        self.registers[h], self.registers[l] = split_word(result)
 
-    @manager.add_instruction(OPCodes.JNZ)
-    def jump_if_not_zero(self) -> None:
+        self.cycles += 5
+
+    @manager.add_instruction(0x0F)
+    def rrc(self) -> None:
+        """
+        The carry bit is set equal to the low-order bit of the accumulator.
+
+        The contents of the accumulator are rotated one bit position
+        to the right, with the low-order bit being transferred to the
+        high-order bit position of the accumulator.
+
+        Condition bits affected: Carry.
+        """
+        accumulator = self.registers[Registers.A] & 0xFF
+        # Obtener el bit menos significativo (LSB) del acumulador
+        new_carry = accumulator & 0x01
+        # Rotar el acumulador a la derecha
+        # El bit de carry se convierte en el bit más significativo (MSB)
+        accumulator = (accumulator >> 1) | (new_carry << 7)
+        # Asegurarse de que el acumulador siga siendo de 8 bits
+        accumulator = accumulator & 0xFF
+        self.registers[Registers.A] = accumulator
+        self.flags.C = True if new_carry else False
+        self.cycles += 4
+
+    @manager.add_instruction(0x17)
+    def ral(self):
+        carry = 1 if self.flags.C else 0
+        a_value = self.registers[Registers.A]
+        new_carry = a_value & 0x80
+
+        # Rotar el acumulador a la izquierda
+        # El bit de carry se convierte en el bit menos significativo (LSB)
+        a_value = (a_value << 1) | (carry >> 7)
+
+        # Asegurarse de que el acumulador siga siendo de 8 bits
+        a_value = a_value & 0xFF
+
+        self.registers[Registers.A] = a_value
+        self.flags.C = True if new_carry else False
+        self.cycles += 4
+
+    @manager.add_instruction(0x1F)
+    def rar(self) -> None:
+        """
+        The contents of the accumulator are rotated one bit position to the right.
+
+        The low-order bit of the accumulator replaces the carry bit,
+        while the carry bit replaces the high-order bit of the accumulator.
+
+        Condition bits affected: Carry.
+        """
+        carry = 1 if self.flags.C else 0
+        accumulator = self.registers[Registers.A] & 0xFF
+        # Obtener el bit menos significativo (LSB) del acumulador
+        new_carry = accumulator & 0x01
+        # Rotar el acumulador a la derecha
+        # El bit de carry se convierte en el bit más significativo (MSB)
+        accumulator = (accumulator >> 1) | (carry << 7)
+        # Asegurarse de que el acumulador siga siendo de 8 bits
+        accumulator = accumulator & 0xFF
+        self.registers[Registers.A] = accumulator
+        self.flags.C = True if new_carry else False
+        self.cycles += 4
+
+    @manager.add_instruction(0x22)
+    def shld(self) -> None:
         address = self.fetch_word()
-        if not self.flags.Z:
-            self.PC = address
+        self.write_memory_byte(address, self.registers[Registers.L])
+        self.write_memory_byte(address + 0x01, self.registers[Registers.H])
+        self.cycles += 16
+
+    @manager.add_instruction(0x27)
+    def daa(self):
+        accumulator = self.registers[Registers.A]
+        carry = 1 if self.flags.C else 0
+        half_carry = 1 if self.flags.A else 0
+
+        lsb = accumulator & 0x0F
+        if half_carry or lsb > 9:
+            accumulator = (accumulator + 0x06) & 0xFF
+            self.flags.A = (lsb + 0x06) > 0xF
+
+        msb = accumulator >> 4
+        if carry or msb > 9:
+            accumulator = (accumulator + 0x60) & 0xFF
+            self.flags.C = (msb + 0x06) > 0x0F
+        else:
+            self.flags.C = False
+
+        self.registers[Registers.A] = accumulator & 0xFF
+        self.flags.Z = (accumulator & 0xFF) == 0x00
+        self.flags.S = (accumulator & 0x80) != 0x00
+        self.flags.P = (bin(accumulator & 0xFF).count("1") % 2) == 0
+
+    @manager.add_instruction(0x2A)
+    def lhld(self) -> None:
+        address1 = self.fetch_word()
+        address2 = (address1 + 0x01) & 0xFFFF
+
+        l = self.read_memory_byte(address1)
+        h = self.read_memory_byte(address2)
+
+        self.registers[Registers.L] = l
+        self.registers[Registers.H] = h
+        self.cycles += 16
+
+    @manager.add_instruction(0x2F)
+    def cma(self) -> None:
+        value = self.registers[Registers.A]
+        value ^= 0xFF
+        self.registers[Registers.A] = value
+        self.cycles += 4
+
+    @manager.add_instruction(0x31)
+    def lxi_sp_d16(self) -> None:
+        """
+        Load a 16-bit address from memory to the stack pointer (SP).
+
+        The stack pointer is set to the value of the 16-bit address fetched from memory.
+        """
+        self.SP = self.fetch_word()
+        self.cycles += 10
+
+    @manager.add_instruction(0x32)
+    def sta_addr(self) -> None:
+        """
+        Store the value of the accumulator in memory at the address specified by the next two bytes.
+
+        This instruction fetches a 16-bit address from memory and stores the value of the accumulator at that
+        address. The address is fetched as a 16-bit value from memory and the accumulator is stored in memory
+        as a byte at that address.
+        """
+        address = self.fetch_word()
+        self.write_memory_byte(address, self.registers[Registers.A])
+        self.cycles += 13
+
+    @manager.add_instruction(0x33)
+    def inx_sp(self):
+        self.SP = (self.SP + 0x01) & 0xFFFF
+        self.cycles += 5
+
+    @manager.add_instruction(0x34)
+    def inr_m(self):
+        address = join_bytes(self.registers[Registers.H], self.registers[Registers.L])
+        m_value = self.read_memory_byte(address)
+        result = m_value + 0x01
+        self.write_memory_byte(address, result)
+
+        self.flags.S = (result & 0x80) != 0x00
+        self.flags.Z = (result & 0xFF) == 0x00
+        self.flags.A = (get_ls_nib(m_value) + 0x01) > 0x0F
+        self.flags.P = bin(result & 0xFF).count("1") % 2 == 0
+        self.cycles += 10
+
+    @manager.add_instruction(0x35)
+    def dcr_m(self) -> None:
+        address = join_bytes(
+            self.registers[Registers.H],
+            self.registers[Registers.L],
+        )
+        result = self.decrement_byte_value(self.read_memory_byte(address))
+        self.write_memory_byte(address, result)
 
         self.cycles += 10
 
-    @manager.add_instruction(OPCodes.MVI_M)
+    @manager.add_instruction(0x36)
     def move_immediate_to_hl_memory(self) -> None:
         address = join_bytes(self.registers[Registers.H], self.registers[Registers.L])
         self.write_memory_byte(address, self.fetch_byte())
         self.cycles += 10
+
+    @manager.add_instruction(0x37)
+    def set_carry(self):
+        self.flags.C = True
+        self.cycles += 4
+
+    @manager.add_instruction(0x39)
+    def dad_sp(self) -> None:
+        h_value, l_value = split_word(self.SP)
+
+        value1 = join_bytes(h_value, l_value)
+        value2 = join_bytes(self.registers[Registers.H], self.registers[Registers.L])
+
+        result = value1 + value2
+        new_value = result & 0xFFFF
+        self.registers[Registers.H], self.registers[Registers.L] = split_word(new_value)
+
+        self.set_carry_flag(result, mask=0xFFFF)
+
+        self.cycles += 10
+
+    @manager.add_instruction(0x3A)
+    def lda_addr(self) -> None:
+        """
+        Load the value at the specified memory address to the accumulator (A register).
+
+        This instruction fetches a 16-bit address from memory and loads the value stored at that address
+        to the accumulator. The value is loaded as a byte, not a word.
+        """
+        address = self.fetch_word()
+        value = self.read_memory_byte(address)
+        self.registers[Registers.A] = value
+        self.cycles += 13
+
+    @manager.add_instruction(0x3B)
+    def dcx_sp(self):
+        self.SP = (self.SP - 0x01) & 0xFFFF
+        self.cycles += 5
+
+    @manager.add_instruction(0x3F)
+    def cmc(self):
+        self.flags.C = not self.flags.C
+        self.cycles += 4
 
     @manager.add_instruction(0x40, [Registers.B, Registers.B])
     @manager.add_instruction(0x41, [Registers.C, Registers.B])
@@ -421,175 +569,29 @@ class Intel8080(CPU):
         self.registers[dst] = self.registers[src]
         self.cycles += 5
 
-    @manager.add_instruction(OPCodes.CPI_A, [Registers.A])
-    def compare_register_with_immediate(self, register: int) -> None:
-        """
-        The byte of immediate data is compared to the contents of the accumulator.
-        The comparison is performed by internally subtracting the data from the
-        accumulator using two's complement arithmetic, leaving the accumulator
-        unchanged but setting the condition bits by the result.
-
-        Since a subtract operation is performed, the Carry bit will be set if
-        there is no carry out of bit 7.
-        """
-        self.compare_with_twos_complement(self.registers[register], self.fetch_byte())
-        self.cycles += 7
-
-    @manager.add_instruction(OPCodes.DAD_DE, [Registers.D, Registers.E])
-    @manager.add_instruction(OPCodes.DAD_HL, [Registers.H, Registers.L])
-    @manager.add_instruction(OPCodes.DAD_BC, [Registers.B, Registers.C])
-    def sum_register_pair_with_hl(self, h: int, l: int) -> None:
-        """
-        The 16-bit number in the specified register pair is added
-        to the 16-bit number held in the Hand L registers using two's complement arithmetic.
-
-        The result replaces the contents of the Hand L registers.
-
-        Condition bits affected: Carry.
-        """
-        h_value = self.registers[h]
-        l_value = self.registers[l]
-
-        value1 = join_bytes(h_value, l_value)
-        value2 = join_bytes(self.registers[Registers.H], self.registers[Registers.L])
-
-        result = value1 + value2
-        new_value = result & 0xFFFF
-        self.registers[Registers.H], self.registers[Registers.L] = split_word(new_value)
-
-        self.set_carry_flag(result, mask=0xFFFF)
-
-        self.cycles += 10
-
-    @manager.add_instruction(OPCodes.DAD_SP)
-    def sum_register_pair_with_self(self) -> None:
-        h_value, l_value = split_word(self.SP)
-
-        value1 = join_bytes(h_value, l_value)
-        value2 = join_bytes(self.registers[Registers.H], self.registers[Registers.L])
-
-        result = value1 + value2
-        new_value = result & 0xFFFF
-        self.registers[Registers.H], self.registers[Registers.L] = split_word(new_value)
-
-        self.set_carry_flag(result, mask=0xFFFF)
-
-        self.cycles += 10
-
-    @manager.add_instruction(
-        OPCodes.XCHG, [Registers.H, Registers.L, Registers.D, Registers.E]
-    )
-    def exchange_register_pairs(self, h: int, l: int, d: int, e: int) -> None:
-        """
-        The 16 bits of data held in the Hand L registers are exchanged
-        with the 16 bits of data held in the D and E registers.
-
-        Condition bits affected: None
-        """
-        h1 = self.registers[h]
-        l1 = self.registers[l]
-        d1 = self.registers[d]
-        e1 = self.registers[e]
-
-        self.registers[h] = d1
-        self.registers[l] = e1
-        self.registers[d] = h1
-        self.registers[e] = l1
-
-        self.cycles += 5
-
-    @manager.add_instruction(OPCodes.OUT)
-    def out_to_port(self) -> None:
-        port = self.fetch_byte()
-        print(f"OUT: Port: {port}, Value: {self.registers[Registers.A]}")
-        self.cycles += 10
-
-    @manager.add_instruction(OPCodes.RNC)
-    def return_if_not_carry(self) -> None:
-        if not self.flags.C:
-            h, l = self.pop()
-            self.PC = join_bytes(h, l)
-            self.cycles += 11
-            return
-
-        self.cycles += 5
-
-    @manager.add_instruction(OPCodes.RC)
-    def return_if_carry(self) -> None:
-        if self.flags.C:
-            h, l = self.pop()
-            self.PC = join_bytes(h, l)
-            self.cycles += 11
-            return
-
-        self.cycles += 5
-
-    @manager.add_instruction(OPCodes.LHLD)
-    def load_address_and_next_to_hl(self) -> None:
-        address1 = self.fetch_word()
-        address2 = (address1 + 0x01) & 0xFFFF
-
-        l = self.read_memory_byte(address1)
-        h = self.read_memory_byte(address2)
-
-        self.registers[Registers.L] = l
-        self.registers[Registers.H] = h
-
-        self.cycles += 16
-
-    @manager.add_instruction(0xB0, [Registers.B])
-    @manager.add_instruction(0xB1, [Registers.C])
-    @manager.add_instruction(0xB2, [Registers.D])
-    @manager.add_instruction(0xB3, [Registers.E])
-    @manager.add_instruction(0xB4, [Registers.H])
-    @manager.add_instruction(0xB5, [Registers.L])
-    @manager.add_instruction(0xB7, [Registers.A])
-    def ora_reg(self, register: int) -> None:
-        result = self.registers[Registers.A] | self.registers[register]
-        self.registers[Registers.A] = result
-
-        self.flags.S = (result & 0x80) != 0
-        self.flags.Z = (result & 0xFF) == 0
-        self.flags.P = bin(result & 0xFF).count("1") % 2 == 0
-        self.flags.C = False
-        self.flags.A = False
-        self.cycles += 4
-
-    @manager.add_instruction(OPCodes.ORA_M, [Registers.A])
-    def register_or_with_memory(self, register: int) -> None:
-        """
-        The specified byte is logically ORed bit by bit with the
-        contents of the accumulator.
-        The carry bit is reset to zero.
-        """
+    @manager.add_instruction(0x46, [Registers.B])
+    @manager.add_instruction(0x4E, [Registers.C])
+    @manager.add_instruction(0x56, [Registers.D])
+    @manager.add_instruction(0x5E, [Registers.E])
+    @manager.add_instruction(0x66, [Registers.H])
+    @manager.add_instruction(0x6E, [Registers.L])
+    @manager.add_instruction(0x7E, [Registers.A])
+    def mov_reg_m(self, register: int) -> None:
         address = join_bytes(self.registers[Registers.H], self.registers[Registers.L])
-        value = self.read_memory_byte(address)
-        result = self.registers[register] | value
-        self.registers[register] = result
-
-        self.set_flags(result)
-        self.flags.C = False
-
+        self.registers[register] = self.read_memory_byte(address)
         self.cycles += 7
 
-    @manager.add_instruction(0x0B, [Registers.B, Registers.C])
-    @manager.add_instruction(0x1B, [Registers.D, Registers.E])
-    @manager.add_instruction(0x2B, [Registers.H, Registers.L])
-    def dcx_reg16(self, h: int, l: int):
-        value = join_bytes(self.registers[h], self.registers[l])
-        result = value - 0x01
-        result = result & 0xFFFF
-        self.registers[h], self.registers[l] = split_word(result)
-
-        self.cycles += 5
-
-    @manager.add_instruction(OPCodes.JZ)
-    def jump_if_zero(self) -> None:
-        address = self.fetch_word()
-        if self.flags.Z:
-            self.PC = address
-
-        self.cycles += 10
+    @manager.add_instruction(0x70, [Registers.B])
+    @manager.add_instruction(0x71, [Registers.C])
+    @manager.add_instruction(0x72, [Registers.D])
+    @manager.add_instruction(0x73, [Registers.E])
+    @manager.add_instruction(0x74, [Registers.H])
+    @manager.add_instruction(0x75, [Registers.L])
+    @manager.add_instruction(0x77, [Registers.A])
+    def mov_m_reg(self, register: int) -> None:
+        address = join_bytes(self.registers[Registers.H], self.registers[Registers.L])
+        self.write_memory_byte(address, self.registers[register])
+        self.cycles += 7
 
     @manager.add_instruction(0x80, [Registers.B])
     @manager.add_instruction(0x81, [Registers.C])
@@ -612,472 +614,8 @@ class Intel8080(CPU):
         self.registers[Registers.A] = result & 0xFF
         self.cycles += 4
 
-    @manager.add_instruction(OPCodes.JPE)
-    def jump_if_parity(self) -> None:
-        address = self.fetch_word()
-        if self.flags.P:
-            self.PC = address
-            self.cycles += 10
-            return
-
-        self.cycles += 5
-
-    @manager.add_instruction(OPCodes.MOV_A_M, [Registers.A])
-    @manager.add_instruction(OPCodes.MOV_B_M, [Registers.B])
-    @manager.add_instruction(OPCodes.MOV_C_M, [Registers.C])
-    @manager.add_instruction(OPCodes.MOV_D_M, [Registers.D])
-    @manager.add_instruction(OPCodes.MOV_E_M, [Registers.E])
-    @manager.add_instruction(OPCodes.MOV_H_M, [Registers.H])
-    @manager.add_instruction(OPCodes.MOV_L_M, [Registers.L])
-    def move_memory_hl_to_register(self, register: int) -> None:
-        address = join_bytes(self.registers[Registers.H], self.registers[Registers.L])
-        self.registers[register] = self.read_memory_byte(address)
-        self.cycles += 7
-
-    @manager.add_instruction(OPCodes.RAR)
-    def rotate_right_a_through_carry(self) -> None:
-        """
-        The contents of the accumulator are rotated one bit position to the right.
-
-        The low-order bit of the accumulator replaces the carry bit,
-        while the carry bit replaces the high-order bit of the accumulator.
-
-        Condition bits affected: Carry.
-        """
-        carry = 1 if self.flags.C else 0
-        accumulator = self.registers[Registers.A] & 0xFF
-
-        # Obtener el bit menos significativo (LSB) del acumulador
-        new_carry = accumulator & 0x01
-
-        # Rotar el acumulador a la derecha
-        # El bit de carry se convierte en el bit más significativo (MSB)
-        accumulator = (accumulator >> 1) | (carry << 7)
-
-        # Asegurarse de que el acumulador siga siendo de 8 bits
-        accumulator = accumulator & 0xFF
-
-        self.registers[Registers.A] = accumulator
-        self.flags.C = True if new_carry else False
-
-        self.cycles += 4
-
-    @manager.add_instruction(OPCodes.RRC)
-    def rotate_right_a(self) -> None:
-        """
-        The carry bit is set equal to the low-order bit of the accumulator.
-
-        The contents of the accumulator are rotated one bit position
-        to the right, with the low-order bit being transferred to the
-        high-order bit position of the accumulator.
-
-        Condition bits affected: Carry.
-        """
-        accumulator = self.registers[Registers.A] & 0xFF
-
-        # Obtener el bit menos significativo (LSB) del acumulador
-        new_carry = accumulator & 0x01
-
-        # Rotar el acumulador a la derecha
-        # El bit de carry se convierte en el bit más significativo (MSB)
-        accumulator = (accumulator >> 1) | (new_carry << 7)
-
-        # Asegurarse de que el acumulador siga siendo de 8 bits
-        accumulator = accumulator & 0xFF
-
-        self.registers[Registers.A] = accumulator
-        self.flags.C = True if new_carry else False
-
-        self.cycles += 4
-
-    @manager.add_instruction(OPCodes.RLC)
-    def rotate_left_accumulator(self) -> None:
-        """
-        The carry bit is set equal to the high-order bit of the accumulator.
-
-        The contents of the accumulator are rotated one bit position
-        to the left, with the high-order bit being transferred to the
-        low-order bit position of the accumulator.
-
-        Condition bits affected: Carry.
-        """
-        accumulator = self.registers[Registers.A] & 0xFF
-
-        # Obtener el bit menos significativo (LSB) del acumulador
-        new_carry = accumulator & 0x80
-
-        # Rotar el acumulador a la izquierda
-        # El bit de carry se convierte en el bit menos significativo (LSB)
-        accumulator = (accumulator << 1) | (new_carry >> 7)
-
-        # Asegurarse de que el acumulador siga siendo de 8 bits
-        accumulator = accumulator & 0xFF
-
-        self.registers[Registers.A] = accumulator
-        self.flags.C = True if new_carry else False
-
-        self.cycles += 4
-
-    @manager.add_instruction(OPCodes.JNC)
-    def jump_if_not_carry(self) -> None:
-        address = self.fetch_word()
-        if not self.flags.C:
-            self.PC = address
-
-        self.cycles += 10
-
-    @manager.add_instruction(OPCodes.JC)
-    def jump_if_carry(self) -> None:
-        address = self.fetch_word()
-        if self.flags.C:
-            self.PC = address
-
-        self.cycles += 10
-
-    @manager.add_instruction(OPCodes.PUSH_PSW)
-    def push_processor_state_word(self) -> None:
-        self.push(self.registers[Registers.A], self.flags.get_flags())
-        self.cycles += 11
-
-    @manager.add_instruction(OPCodes.POP_PSW)
-    def pop_processor_state_word(self) -> None:
-        self.registers[Registers.A], flags_byte = self.pop()
-        self.flags.set_flags(flags_byte)
-        self.cycles += 10
-
-    @manager.add_instruction(OPCodes.ANI)
-    def accumulator_and_immediate(self) -> None:
-        value1 = self.registers[Registers.A]
-        value2 = self.fetch_byte()
-
-        result = value1 & value2
-        self.registers[Registers.A] = result
-
-        self.set_flags(result)
-        self.flags.C = False
-        self.set_aux_carry_flag(value1, value2)
-
-        self.cycles += 7
-
-    @manager.add_instruction(OPCodes.JM)
-    def jump_if_minus(self) -> None:
-        address = self.fetch_word()
-        if self.flags.S:
-            self.PC = address
-
-        self.cycles += 10
-
-    @manager.add_instruction(OPCodes.ADI)
-    def add_immediate_to_accumulator(self) -> None:
-        """
-        The byte of immediate data is added to the contents
-        of the accumulator using two's complement arithmetic.
-
-        Condition bits affected: Carry, Sign, Zero,
-        Parity, Auxiliary Carry.
-        """
-        i_value = self.fetch_byte()
-        a_value = self.registers[Registers.A]
-        result = i_value + a_value
-        new_value = result & 0xFF
-
-        self.registers[Registers.A] = new_value
-
-        self.set_flags(new_value)
-        self.set_carry_flag(result)
-        self.set_aux_carry_flag(i_value, a_value)
-
-        self.cycles += 7
-
-    @manager.add_instruction(0xA8, [Registers.B])
-    @manager.add_instruction(0xA9, [Registers.C])
-    @manager.add_instruction(0xAA, [Registers.D])
-    @manager.add_instruction(0xAB, [Registers.E])
-    @manager.add_instruction(0xAC, [Registers.H])
-    @manager.add_instruction(0xAD, [Registers.L])
-    @manager.add_instruction(0xAF, [Registers.A])
-    def xra(self, register: int) -> None:
-        value1 = self.registers[Registers.A]
-        value2 = self.registers[register]
-
-        result = value1 ^ value2
-        self.registers[Registers.A] = result
-
-        self.flags.S = (result & 0x80) != 0
-        self.flags.Z = (result & 0xFF) == 0
-        self.flags.P = bin(result & 0xFF).count("1") % 2 == 0
-        self.flags.C = False
-        self.cycles += 4
-
-    @manager.add_instruction(OPCodes.EI)
-    def enable_interrupts(self) -> None:
-        self.interrupts_enabled = True
-        self.cycles += 4
-
-    @manager.add_instruction(0xA0, [Registers.B])
-    @manager.add_instruction(0xA1, [Registers.C])
-    @manager.add_instruction(0xA2, [Registers.D])
-    @manager.add_instruction(0xA3, [Registers.E])
-    @manager.add_instruction(0xA4, [Registers.H])
-    @manager.add_instruction(0xA5, [Registers.L])
-    @manager.add_instruction(0xA7, [Registers.A])
-    def ana_reg(self, register: int) -> None:
-        a_value = self.registers[Registers.A]
-        value2 = self.registers[register]
-        result = a_value & value2
-        self.registers[Registers.A] = result
-
-        self.flags.S = (result & 0x80) != 0
-        self.flags.Z = (result & 0xFF) == 0
-        self.flags.P = bin(result & 0xFF).count("1") % 2 == 0
-        self.flags.C = False
-        self.flags.A = (get_ls_nib(a_value) + get_ls_nib(value2)) > 0xF
-
-        self.cycles += 4
-
-    @manager.add_instruction(OPCodes.STC)
-    def set_carry(self):
-        self.flags.C = True
-
-        self.cycles += 4
-
-    @manager.add_instruction(OPCodes.RZ)
-    def return_if_zero(self) -> None:
-        if self.flags.Z:
-            h, l = self.pop()
-            self.PC = join_bytes(h, l)
-            self.cycles += 11
-            return
-
-        self.cycles += 5
-
-    @manager.add_instruction(OPCodes.RNZ)
-    def return_if_not_zero(self) -> None:
-        if not self.flags.Z:
-            h, l = self.pop()
-            self.PC = join_bytes(h, l)
-            self.cycles += 11
-            return
-
-        self.cycles += 5
-
-    @manager.add_instruction(OPCodes.IN)
-    def input(self) -> int:
-        port = self.fetch_byte()
-        if port == 0x01:
-            self.registers[Registers.A] = self.port_1
-        self.cycles += 10
-
-    @manager.add_instruction(OPCodes.XTHL)
-    def exchange_sp_hl(self) -> None:
-        h, l = self.registers[Registers.H], self.registers[Registers.L]
-        self.registers[Registers.L] = self.read_memory_byte(self.SP)
-        self.registers[Registers.H] = self.read_memory_byte(self.SP + 0x01)
-        self.write_memory_word(self.SP, h, l)
-        self.cycles += 18
-
-    @manager.add_instruction(OPCodes.PCHL)
-    def load_stack_pointer(self) -> None:
-        h = self.registers[Registers.H]
-        l = self.registers[Registers.L]
-        self.PC = join_bytes(h, l)
-
-        self.cycles += 5
-
-    @manager.add_instruction(OPCodes.DCR_M)
-    def decrement_memory_byte(self) -> None:
-        address = join_bytes(
-            self.registers[Registers.H],
-            self.registers[Registers.L],
-        )
-        result = self.decrement_byte_value(self.read_memory_byte(address))
-        self.write_memory_byte(address, result)
-
-        self.cycles += 10
-
-    @manager.add_instruction(OPCodes.CZ)
-    def call_if_zero(self) -> None:
-        address = self.fetch_word()
-        if self.flags.Z:
-            h, l = split_word(self.PC)
-            self.push(h, l)
-            self.PC = address
-            self.cycles += 17
-            return
-
-        self.cycles += 11
-
-    @manager.add_instruction(OPCodes.CNZ)
-    def call_if_not_zero(self) -> None:
-        address = self.fetch_word()
-        if not self.flags.Z:
-            h, l = split_word(self.PC)
-            self.push(h, l)
-            self.PC = address
-            self.cycles += 17
-            return
-
-        self.cycles += 11
-
-    @manager.add_instruction(OPCodes.RST_1)
-    def rst_1(self) -> None:
-        if self.interrupts_enabled:
-            self.interrupts_enabled = False
-            h, l = split_word(self.PC)
-            self.push(h, l)
-            self.PC = 0x08
-            self.cycles += 11
-
-    @manager.add_instruction(OPCodes.RST_2)
-    def rst_2(self) -> None:
-        if self.interrupts_enabled:
-            self.interrupts_enabled = False
-            h, l = split_word(self.PC)
-            self.push(h, l)
-            self.PC = 0x10
-            self.cycles += 11
-
-    @manager.add_instruction(0xDF)
-    def rst_3(self) -> None:
-        if self.interrupts_enabled:
-            self.interrupts_enabled = False
-            h, l = split_word(self.PC)
-            self.push(h, l)
-            self.PC = 0x08 * 3
-            self.cycles += 11
-
-    @manager.add_instruction(0xE7)
-    def rst_4(self) -> None:
-        if self.interrupts_enabled:
-            self.interrupts_enabled = False
-            h, l = split_word(self.PC)
-            self.push(h, l)
-            self.PC = 0x20
-            self.cycles += 11
-
-    @manager.add_instruction(0xEF)
-    def rst_5(self) -> None:
-        if self.interrupts_enabled:
-            self.interrupts_enabled = False
-            h, l = split_word(self.PC)
-            self.push(h, l)
-            self.PC = 0x08 * 5
-            self.cycles += 11
-
-    @manager.add_instruction(OPCodes.SUI)
-    def substract_immediate_from_accumulator(self) -> None:
-        i_value = self.fetch_byte()
-        a_value = self.registers[Registers.A]
-        result = a_value - i_value
-        new_value = result & 0xFF
-
-        self.registers[Registers.A] = new_value
-
-        self.set_flags(new_value)
-        self.set_carry_flag(result)
-
-        # twos complement
-        x = (i_value ^ 0xFF) + 0x01
-
-        c = ((x & 0xF) + (a_value & 0xF)) > 0xF
-        self.flags.A = c
-
-        self.cycles += 7
-
-    @manager.add_instruction(OPCodes.SBI)
-    def substract_immediate_from_accumulator_with_borrow(self) -> None:
-        carry = 1 if self.flags.C else 0
-        i_value = self.fetch_byte()
-        i_value += carry
-        i_value &= 0xFF
-
-        a_value = self.registers[Registers.A]
-        result = a_value - i_value
-        new_value = result & 0xFF
-
-        self.registers[Registers.A] = new_value
-        self.set_flags(new_value)
-        self.set_carry_flag(result)
-
-        # twos complement
-        x = (i_value ^ 0xFF) + 0x01
-
-        c = ((x & 0xF) + (a_value & 0xF)) > 0xF
-        self.flags.A = c
-
-        self.cycles += 7
-
-    @manager.add_instruction(OPCodes.ORI)
-    def or_immeditate_with_accumulator(self) -> None:
-        i_value = self.fetch_byte()
-        a_value = self.registers[Registers.A]
-        result = a_value | i_value
-        self.registers[Registers.A] = result
-
-        self.set_flags(result)
-        self.set_carry_flag(result)
-        self.set_aux_carry_flag(a_value, i_value)
-
-        self.cycles += 7
-
-    @manager.add_instruction(OPCodes.RM)
-    def return_if_minus(self) -> None:
-        if self.flags.S:
-            h, l = self.pop()
-            self.PC = join_bytes(h, l)
-            self.cycles += 11
-            return
-
-        self.cycles += 5
-
-    @manager.add_instruction(0xF7)
-    def rst_7(self) -> None:
-        self.interrupts_enabled = False
-        h, l = split_word(self.PC)
-        self.push(h, l)
-        self.PC = 0x30
-        self.cycles += 11
-
-    @manager.add_instruction(OPCodes.RST_7)
-    def rst_7(self) -> None:
-        self.interrupts_enabled = False
-        h, l = split_word(self.PC)
-        self.push(h, l)
-        self.PC = 0x38
-        self.cycles += 11
-
-    @manager.add_instruction(OPCodes.SHLD)
-    def store_hl_to_direct_address(self) -> None:
-        address = self.fetch_word()
-        self.write_memory_byte(address, self.registers[Registers.L])
-        self.write_memory_byte(address + 0x01, self.registers[Registers.H])
-
-        self.cycles += 16
-
-    @manager.add_instruction(OPCodes.CPE)
-    def call_if_parity_even(self) -> None:
-        address = self.fetch_word()
-        if self.flags.P:
-            h, l = split_word(self.PC)
-            self.push(h, l)
-            self.PC = address
-            self.cycles += 17
-            return
-
-        self.cycles += 11
-
-    @manager.add_instruction(OPCodes.RP)
-    def return_if_parity_even(self) -> None:
-        if self.flags.P:
-            h, l = self.pop()
-            self.PC = join_bytes(h, l)
-            self.cycles += 11
-            return
-
-        self.cycles += 5
-
-    @manager.add_instruction(OPCodes.ADD_M)
-    def add_memory_to_accumulator(self) -> None:
+    @manager.add_instruction(0x86)
+    def add_m(self) -> None:
         value1 = self.registers[Registers.A]
         h = self.registers[Registers.H]
         l = self.registers[Registers.L]
@@ -1090,138 +628,7 @@ class Intel8080(CPU):
         self.set_flags(new_value)
         self.set_carry_flag(result)
         self.set_aux_carry_flag(value1, value2)
-
         self.cycles += 7
-
-    @manager.add_instruction(OPCodes.CMA)
-    def complement_accumulator(self) -> None:
-        value = self.registers[Registers.A]
-        value ^= 0xFF
-        self.registers[Registers.A] = value
-        self.cycles += 4
-
-    @manager.add_instruction(OPCodes.ANA_M)
-    def and_memory_to_accumulator(self) -> None:
-        value1 = self.registers[Registers.A]
-        h = self.registers[Registers.H]
-        l = self.registers[Registers.L]
-        value2 = self.read_memory_byte(join_bytes(h, l))
-
-        result = value1 & value2
-        self.registers[Registers.A] = result
-
-        self.set_flags(result)
-        self.set_aux_carry_flag(value1, value2)
-        self.flags.C = False
-
-        self.cycles += 7
-
-    @manager.add_instruction(0x12, [Registers.D, Registers.E])
-    @manager.add_instruction(0x02, [Registers.B, Registers.C])
-    def stax_reg(self, r1: int, r2: int):
-        address = join_bytes(self.registers[r1], self.registers[r2])
-        self.write_memory_byte(address, self.registers[Registers.A])
-        self.cycles += 7
-
-    @manager.add_instruction(OPCodes.INR_M)
-    def increment_memory_address(self):
-        address = join_bytes(self.registers[Registers.H], self.registers[Registers.L])
-        m_value = self.read_memory_byte(address)
-        result = m_value + 0x01
-        self.write_memory_byte(address, result)
-
-        self.flags.S = (result & 0x80) != 0x00
-        self.flags.Z = (result & 0xFF) == 0x00
-        self.flags.A = (get_ls_nib(m_value) + 0x01) > 0x0F
-        self.flags.P = bin(result & 0xFF).count("1") % 2 == 0
-
-        self.cycles += 10
-
-    @manager.add_instruction(0xB8, [Registers.B])
-    @manager.add_instruction(0xB9, [Registers.C])
-    @manager.add_instruction(0xBA, [Registers.D])
-    @manager.add_instruction(0xBB, [Registers.E])
-    @manager.add_instruction(0xBC, [Registers.H])
-    @manager.add_instruction(0xBD, [Registers.L])
-    @manager.add_instruction(0xBF, [Registers.A])
-    def cmp_reg(self, register: int) -> None:
-        a_value = self.registers[Registers.A]
-        reg_value = self.registers[register]
-        compl = get_twos_complement(reg_value)
-        result = a_value + compl
-
-        self.flags.Z = (result & 0xFF) == 0x00
-        self.flags.S = (result & 0x80) != 0
-        self.flags.P = (bin(result & 0xFF).count("1") % 2) == 0
-        self.flags.C = result <= 0xFF
-
-        self.flags.A = (get_ls_nib(a_value) + get_ls_nib(compl)) > 0x0F
-        self.cycles += 4
-
-    @manager.add_instruction(OPCodes.CNC)
-    def call_if_not_carry(self):
-        address = self.fetch_word()
-        if not self.flags.C:
-            h, l = split_word(self.PC)
-            self.push(h, l)
-            self.PC = address
-            self.cycles += 17
-            return
-
-        self.cycles += 11
-
-    @manager.add_instruction(OPCodes.CMP_M)
-    def compare_register_with_memory(self) -> None:
-        address = join_bytes(self.registers[Registers.H], self.registers[Registers.L])
-        self.compare_with_twos_complement(
-            self.registers[Registers.A], self.read_memory_byte(address)
-        )
-        self.cycles += 7
-
-    @manager.add_instruction(0x90, [Registers.B])
-    @manager.add_instruction(0x91, [Registers.C])
-    @manager.add_instruction(0x92, [Registers.D])
-    @manager.add_instruction(0x93, [Registers.E])
-    @manager.add_instruction(0x94, [Registers.H])
-    @manager.add_instruction(0x95, [Registers.L])
-    @manager.add_instruction(0x97, [Registers.A])
-    def sub_reg(self, register: int) -> None:
-        a_value = self.registers[Registers.A]
-        reg_value = self.registers[register]
-        compl = get_twos_complement(reg_value)
-        result = a_value + compl
-
-        self.flags.S = (result & 0x80) != 0x00
-        self.flags.Z = (result & 0xFF) == 0x00
-        self.flags.P = (bin(result & 0xFF).count("1") % 2) == 0
-        self.flags.A = (get_ls_nib(a_value) + get_ls_nib(compl)) > 0x0F
-        self.flags.C = result <= 0xFF
-
-        self.registers[Registers.A] = result & 0xFF
-        self.cycles += 4
-
-    @manager.add_instruction(0x27)
-    def daa(self):
-        accumulator = self.registers[Registers.A]
-        carry = 1 if self.flags.C else 0
-        half_carry = 1 if self.flags.A else 0
-
-        lsb = accumulator & 0x0F
-        if half_carry or lsb > 9:
-            accumulator = (accumulator + 0x06) & 0xFF
-            self.flags.A = (lsb + 0x06) > 0xF
-
-        msb = accumulator >> 4
-        if carry or msb > 9:
-            accumulator = (accumulator + 0x60) & 0xFF
-            self.flags.C = (msb + 0x06) > 0x0F
-        else:
-            self.flags.C = False
-
-        self.registers[Registers.A] = accumulator & 0xFF
-        self.flags.Z = (accumulator & 0xFF) == 0x00
-        self.flags.S = (accumulator & 0x80) != 0x00
-        self.flags.P = (bin(accumulator & 0xFF).count("1") % 2) == 0
 
     @manager.add_instruction(0x88, [Registers.B])
     @manager.add_instruction(0x89, [Registers.C])
@@ -1246,78 +653,64 @@ class Intel8080(CPU):
 
         self.cycles += 4
 
-    @manager.add_instruction(0xF9)
-    def sphl(self) -> None:
-        self.SP = join_bytes(self.registers[Registers.H], self.registers[Registers.L])
-        self.cycles += 5
-
-    @manager.add_instruction(0x33)
-    def inx_sp(self):
-        self.SP = (self.SP + 0x01) & 0xFFFF
-        self.cycles += 5
-
-    @manager.add_instruction(0x3B)
-    def dcx_sp(self):
-        self.SP = (self.SP - 0x01) & 0xFFFF
-        self.cycles += 5
-
-    @manager.add_instruction(0xFC)
-    def cm_addr(self) -> None:
-        address = self.fetch_word()
-        if self.flags.S:
-            h, l = split_word(self.PC)
-            self.push(h, l)
-            self.PC = address
-            self.cycles += 17
-            return
-
-        self.cycles += 11
-
-    @manager.add_instruction(0x3F)
-    def cmc(self):
-        self.flags.C = not self.flags.C
-        self.cycles += 4
-
-    @manager.add_instruction(0xF4)
-    def cp_addr(self) -> None:
-        address = self.fetch_word()
-        if not self.flags.S:
-            h, l = split_word(self.PC)
-            self.push(h, l)
-            self.PC = address
-            self.cycles += 17
-            return
-
-        self.cycles += 11
-
-    @manager.add_instruction(0xF2)
-    def jp(self):
-        address = self.fetch_word()
-        if not self.flags.S:
-            self.PC = address
-
-        self.cycles += 10
-
-    @manager.add_instruction(0x9E)
-    def sbb_m(self):
+    @manager.add_instruction(0x8E)
+    def adc_m(self) -> None:
         a_value = self.registers[Registers.A]
 
         address = join_bytes(self.registers[Registers.H], self.registers[Registers.L])
         value_2 = self.read_memory_byte(address)
 
         value_2 += 1 if self.flags.C else 0
-        compl = get_twos_complement(value_2)
-
-        result = a_value + compl
-        self.registers[Registers.A] = result & 0xFF
+        result = a_value + value_2
 
         self.flags.S = (result & 0x80) != 0x00
         self.flags.Z = (result & 0xFF) == 0x00
-        self.flags.P = bin(result & 0xFF).count("1") % 2 == 0
+        self.flags.P = (bin(result & 0xFF).count("1") % 2) == 0
+        self.flags.A = (get_ls_nib(a_value) + get_ls_nib(value_2)) > 0x0F
+        self.flags.C = result > 0xFF
 
-        self.flags.C = result <= 0xFF
+        self.registers[Registers.A] = result & 0xFF
+        self.cycles += 4
+
+    @manager.add_instruction(0x90, [Registers.B])
+    @manager.add_instruction(0x91, [Registers.C])
+    @manager.add_instruction(0x92, [Registers.D])
+    @manager.add_instruction(0x93, [Registers.E])
+    @manager.add_instruction(0x94, [Registers.H])
+    @manager.add_instruction(0x95, [Registers.L])
+    @manager.add_instruction(0x97, [Registers.A])
+    def sub_reg(self, register: int) -> None:
+        a_value = self.registers[Registers.A]
+        reg_value = self.registers[register]
+        compl = get_twos_complement(reg_value)
+        result = a_value + compl
+
+        self.flags.S = (result & 0x80) != 0x00
+        self.flags.Z = (result & 0xFF) == 0x00
+        self.flags.P = (bin(result & 0xFF).count("1") % 2) == 0
         self.flags.A = (get_ls_nib(a_value) + get_ls_nib(compl)) > 0x0F
+        self.flags.C = result <= 0xFF
 
+        self.registers[Registers.A] = result & 0xFF
+        self.cycles += 4
+
+    @manager.add_instruction(0x96)
+    def sub_m(self) -> None:
+        a_value = self.registers[Registers.A]
+
+        address = join_bytes(self.registers[Registers.H], self.registers[Registers.L])
+        value_2 = self.read_memory_byte(address)
+
+        compl = get_twos_complement(value_2)
+        result = a_value + compl
+
+        self.flags.S = (result & 0x80) != 0x00
+        self.flags.Z = (result & 0xFF) == 0x00
+        self.flags.P = (bin(result & 0xFF).count("1") % 2) == 0
+        self.flags.A = (get_ls_nib(a_value) + get_ls_nib(compl)) > 0x0F
+        self.flags.C = result <= 0xFF
+
+        self.registers[Registers.A] = result & 0xFF
         self.cycles += 4
 
     @manager.add_instruction(0x98, [Registers.B])
@@ -1343,20 +736,83 @@ class Intel8080(CPU):
 
         self.flags.C = result <= 0xFF
         self.flags.A = (get_ls_nib(a_value) + get_ls_nib(compl)) > 0x0F
+        self.cycles += 4
+
+    @manager.add_instruction(0x9E)
+    def sbb_m(self):
+        a_value = self.registers[Registers.A]
+
+        address = join_bytes(self.registers[Registers.H], self.registers[Registers.L])
+        value_2 = self.read_memory_byte(address)
+
+        value_2 += 1 if self.flags.C else 0
+        compl = get_twos_complement(value_2)
+
+        result = a_value + compl
+        self.registers[Registers.A] = result & 0xFF
+
+        self.flags.S = (result & 0x80) != 0x00
+        self.flags.Z = (result & 0xFF) == 0x00
+        self.flags.P = bin(result & 0xFF).count("1") % 2 == 0
+        self.flags.C = result <= 0xFF
+        self.flags.A = (get_ls_nib(a_value) + get_ls_nib(compl)) > 0x0F
+        self.cycles += 4
+
+    @manager.add_instruction(0xA0, [Registers.B])
+    @manager.add_instruction(0xA1, [Registers.C])
+    @manager.add_instruction(0xA2, [Registers.D])
+    @manager.add_instruction(0xA3, [Registers.E])
+    @manager.add_instruction(0xA4, [Registers.H])
+    @manager.add_instruction(0xA5, [Registers.L])
+    @manager.add_instruction(0xA7, [Registers.A])
+    def ana_reg(self, register: int) -> None:
+        a_value = self.registers[Registers.A]
+        value2 = self.registers[register]
+        result = a_value & value2
+        self.registers[Registers.A] = result
+
+        self.flags.S = (result & 0x80) != 0
+        self.flags.Z = (result & 0xFF) == 0
+        self.flags.P = bin(result & 0xFF).count("1") % 2 == 0
+        self.flags.C = False
+        self.flags.A = (get_ls_nib(a_value) + get_ls_nib(value2)) > 0xF
 
         self.cycles += 4
 
-    @manager.add_instruction(0xDC)
-    def cc(self):
-        address = self.fetch_word()
-        if self.flags.C:
-            h, l = split_word(self.PC)
-            self.push(h, l)
-            self.PC = address
-            self.cycles += 17
-            return
+    @manager.add_instruction(0xA6)
+    def and_memory_to_accumulator(self) -> None:
+        value1 = self.registers[Registers.A]
+        h = self.registers[Registers.H]
+        l = self.registers[Registers.L]
+        value2 = self.read_memory_byte(join_bytes(h, l))
 
-        self.cycles += 11
+        result = value1 & value2
+        self.registers[Registers.A] = result
+
+        self.set_flags(result)
+        self.set_aux_carry_flag(value1, value2)
+        self.flags.C = False
+        self.cycles += 7
+
+    @manager.add_instruction(0xA8, [Registers.B])
+    @manager.add_instruction(0xA9, [Registers.C])
+    @manager.add_instruction(0xAA, [Registers.D])
+    @manager.add_instruction(0xAB, [Registers.E])
+    @manager.add_instruction(0xAC, [Registers.H])
+    @manager.add_instruction(0xAD, [Registers.L])
+    @manager.add_instruction(0xAF, [Registers.A])
+    def xra(self, register: int) -> None:
+        value1 = self.registers[Registers.A]
+        value2 = self.registers[register]
+
+        result = value1 ^ value2
+        self.registers[Registers.A] = result
+
+        self.flags.S = (result & 0x80) != 0
+        self.flags.Z = (result & 0xFF) == 0
+        self.flags.P = bin(result & 0xFF).count("1") % 2 == 0
+        self.flags.C = False
+        self.cycles += 4
 
     @manager.add_instruction(0xAE, [Registers.A])
     def xra_m(self, r1: int) -> None:
@@ -1373,8 +829,223 @@ class Intel8080(CPU):
         self.flags.P = bin(result & 0xFF).count("1") % 2 == 0
         self.flags.A = False
         self.flags.C = False
-
         self.cycles += 4
+
+    @manager.add_instruction(0xB0, [Registers.B])
+    @manager.add_instruction(0xB1, [Registers.C])
+    @manager.add_instruction(0xB2, [Registers.D])
+    @manager.add_instruction(0xB3, [Registers.E])
+    @manager.add_instruction(0xB4, [Registers.H])
+    @manager.add_instruction(0xB5, [Registers.L])
+    @manager.add_instruction(0xB7, [Registers.A])
+    def ora_reg(self, register: int) -> None:
+        result = self.registers[Registers.A] | self.registers[register]
+        self.registers[Registers.A] = result
+
+        self.flags.S = (result & 0x80) != 0
+        self.flags.Z = (result & 0xFF) == 0
+        self.flags.P = bin(result & 0xFF).count("1") % 2 == 0
+        self.flags.C = False
+        self.flags.A = False
+        self.cycles += 4
+
+    @manager.add_instruction(0xB6, [Registers.A])
+    def ora_m(self, register: int) -> None:
+        """
+        The specified byte is logically ORed bit by bit with the
+        contents of the accumulator.
+        The carry bit is reset to zero.
+        """
+        address = join_bytes(self.registers[Registers.H], self.registers[Registers.L])
+        value = self.read_memory_byte(address)
+        result = self.registers[register] | value
+        self.registers[register] = result
+
+        self.set_flags(result)
+        self.flags.C = False
+        self.cycles += 7
+
+    @manager.add_instruction(0xB8, [Registers.B])
+    @manager.add_instruction(0xB9, [Registers.C])
+    @manager.add_instruction(0xBA, [Registers.D])
+    @manager.add_instruction(0xBB, [Registers.E])
+    @manager.add_instruction(0xBC, [Registers.H])
+    @manager.add_instruction(0xBD, [Registers.L])
+    @manager.add_instruction(0xBF, [Registers.A])
+    def cmp_reg(self, register: int) -> None:
+        a_value = self.registers[Registers.A]
+        reg_value = self.registers[register]
+        compl = get_twos_complement(reg_value)
+        result = a_value + compl
+
+        self.flags.Z = (result & 0xFF) == 0x00
+        self.flags.S = (result & 0x80) != 0
+        self.flags.P = (bin(result & 0xFF).count("1") % 2) == 0
+        self.flags.C = result <= 0xFF
+
+        self.flags.A = (get_ls_nib(a_value) + get_ls_nib(compl)) > 0x0F
+        self.cycles += 4
+
+    @manager.add_instruction(0xBE)
+    def cmp_m(self) -> None:
+        address = join_bytes(self.registers[Registers.H], self.registers[Registers.L])
+        self.compare_with_twos_complement(
+            self.registers[Registers.A], self.read_memory_byte(address)
+        )
+        self.cycles += 7
+
+    @manager.add_instruction(0xC0)
+    def rnz(self) -> None:
+        if not self.flags.Z:
+            h, l = self._pop()
+            self.PC = join_bytes(h, l)
+            self.cycles += 11
+            return
+
+        self.cycles += 5
+
+    @manager.add_instruction(0xC1, [Registers.B, Registers.C])
+    @manager.add_instruction(0xD1, [Registers.D, Registers.E])
+    @manager.add_instruction(0xE1, [Registers.H, Registers.L])
+    def pop(self, h: int, l: int) -> None:
+        """
+        Pop two bytes from the stack and store them in the specified registers pair.
+        The stack pointer is incremented by two after the pop.
+        """
+        high, low = self._pop()
+        self.registers[h], self.registers[l] = high, low
+        self.cycles += 10
+
+    @manager.add_instruction(0xC2)
+    def jnz_addr(self) -> None:
+        address = self.fetch_word()
+        if not self.flags.Z:
+            self.PC = address
+
+        self.cycles += 10
+
+    @manager.add_instruction(0xC3)
+    def jmp_addr(self) -> None:
+        """
+        Jump to the specified address.
+
+        This instruction fetches a 16-bit address from memory and sets the
+        program counter (PC) to that address, effectively jumping to the
+        instruction at that location.
+        """
+        address = self.fetch_word()
+        self.PC = address
+        self.cycles += 10
+
+    @manager.add_instruction(0xC4)
+    def cnz_addr(self) -> None:
+        address = self.fetch_word()
+        if not self.flags.Z:
+            h, l = split_word(self.PC)
+            self._push(h, l)
+            self.PC = address
+            self.cycles += 17
+            return
+        self.cycles += 11
+
+    @manager.add_instruction(0xC5, [Registers.B, Registers.C])
+    @manager.add_instruction(0xD5, [Registers.D, Registers.E])
+    @manager.add_instruction(0xE5, [Registers.H, Registers.L])
+    def push(self, h: int, l: int) -> None:
+        """
+        Push the contents of the BC register pair onto the stack.
+
+        This method pushes the values stored in the B and C registers onto the stack.
+        The value in the C register is pushed first as the low byte, followed by the
+        value in the B register as the high byte.
+        """
+        self._push(self.registers[h], self.registers[l])
+        self.cycles += 11
+
+    @manager.add_instruction(0xC6)
+    def adi_d8(self) -> None:
+        """
+        The byte of immediate data is added to the contents
+        of the accumulator using two's complement arithmetic.
+
+        Condition bits affected: Carry, Sign, Zero,
+        Parity, Auxiliary Carry.
+        """
+        i_value = self.fetch_byte()
+        a_value = self.registers[Registers.A]
+        result = i_value + a_value
+        new_value = result & 0xFF
+
+        self.registers[Registers.A] = new_value
+
+        self.set_flags(new_value)
+        self.set_carry_flag(result)
+        self.set_aux_carry_flag(i_value, a_value)
+
+        self.cycles += 7
+
+    @manager.add_instruction(0xC8)
+    def rz(self) -> None:
+        if self.flags.Z:
+            h, l = self._pop()
+            self.PC = join_bytes(h, l)
+            self.cycles += 11
+            return
+
+        self.cycles += 5
+
+    @manager.add_instruction(0xC9)
+    def ret(self) -> None:
+        """
+        Return from a subroutine call by restoring the program counter.
+
+        This method pops two bytes from the stack and uses them to
+        restore the program counter (PC) to the address from which
+        the subroutine was called. The high byte is popped first,
+        followed by the low byte, and they are combined to form the
+        complete address.
+        """
+        h, l = self._pop()
+        self.PC = h << 0x08 | l & 0xFF
+        self.cycles += 10
+
+    @manager.add_instruction(0xCA)
+    def jz_addr(self) -> None:
+        address = self.fetch_word()
+        if self.flags.Z:
+            self.PC = address
+        self.cycles += 10
+
+    @manager.add_instruction(0xCC)
+    def cz_addr(self) -> None:
+        address = self.fetch_word()
+        if self.flags.Z:
+            h, l = split_word(self.PC)
+            self._push(h, l)
+            self.PC = address
+            self.cycles += 17
+            return
+
+        self.cycles += 11
+
+    @manager.add_instruction(0xCD)
+    def call_addr(self) -> None:
+        """
+        Call the subroutine at the specified address.
+
+        This function fetches a 16-bit address from memory and sets the program counter (PC)
+        to that address, effectively jumping to the subroutine at that location. Before jumping,
+        it pushes the current PC onto the stack to allow returning to the original location after
+        the subroutine completes.
+
+        The fetch_word method is used to retrieve the 16-bit address from memory, and the current PC
+        is split into high and low bytes and pushed onto the stack.
+        """
+        address_to_jump = self.fetch_word()
+        h, l = split_word(self.PC)
+        self._push(h, l)
+        self.PC = address_to_jump
+        self.cycles += 17
 
     @manager.add_instruction(0xCE)
     def aci_d8(self):
@@ -1389,48 +1060,253 @@ class Intel8080(CPU):
         self.flags.S = self.registers[Registers.A] & 0x80 != 0x00
         self.flags.P = bin(result & 0xFF).count("1") % 2 == 0
         self.flags.A = (get_ls_nib(value1) + get_ls_nib(value2) + self.flags.C) > 0x0F
-
         self.cycles += 7
 
-    @manager.add_instruction(0x96)
-    def sub_m(self) -> None:
+    @manager.add_instruction(0xCF)
+    def rst_1(self) -> None:
+        if self.interrupts_enabled:
+            self.interrupts_enabled = False
+            h, l = split_word(self.PC)
+            self._push(h, l)
+            self.PC = 0x08
+            self.cycles += 11
+
+    @manager.add_instruction(0xD0)
+    def rnc(self) -> None:
+        if not self.flags.C:
+            h, l = self._pop()
+            self.PC = join_bytes(h, l)
+            self.cycles += 11
+            return
+        self.cycles += 5
+
+    @manager.add_instruction(0xD2)
+    def jnc_addr(self) -> None:
+        address = self.fetch_word()
+        if not self.flags.C:
+            self.PC = address
+        self.cycles += 10
+
+    @manager.add_instruction(0xD3)
+    def out_d8(self) -> None:
+        port = self.fetch_byte()
+        print(f"OUT: Port: {port}, Value: {self.registers[Registers.A]}")
+        self.cycles += 10
+
+    @manager.add_instruction(0xD4)
+    def cnc_addr(self):
+        address = self.fetch_word()
+        if not self.flags.C:
+            h, l = split_word(self.PC)
+            self._push(h, l)
+            self.PC = address
+            self.cycles += 17
+            return
+        self.cycles += 11
+
+    @manager.add_instruction(0xD6)
+    def sui_d8(self) -> None:
+        i_value = self.fetch_byte()
         a_value = self.registers[Registers.A]
+        result = a_value - i_value
+        new_value = result & 0xFF
+        self.registers[Registers.A] = new_value
+        self.set_flags(new_value)
+        self.set_carry_flag(result)
+        # twos complement
+        x = (i_value ^ 0xFF) + 0x01
+        c = ((x & 0xF) + (a_value & 0xF)) > 0xF
+        self.flags.A = c
+        self.cycles += 7
 
-        address = join_bytes(self.registers[Registers.H], self.registers[Registers.L])
-        value_2 = self.read_memory_byte(address)
+    @manager.add_instruction(0xD7)
+    def rst_2(self) -> None:
+        if self.interrupts_enabled:
+            self.interrupts_enabled = False
+            h, l = split_word(self.PC)
+            self._push(h, l)
+            self.PC = 0x10
+            self.cycles += 11
 
-        compl = get_twos_complement(value_2)
-        result = a_value + compl
+    @manager.add_instruction(0xD8)
+    def rc(self) -> None:
+        if self.flags.C:
+            h, l = self._pop()
+            self.PC = join_bytes(h, l)
+            self.cycles += 11
+            return
+        self.cycles += 5
 
-        self.flags.S = (result & 0x80) != 0x00
-        self.flags.Z = (result & 0xFF) == 0x00
-        self.flags.P = (bin(result & 0xFF).count("1") % 2) == 0
-        self.flags.A = (get_ls_nib(a_value) + get_ls_nib(compl)) > 0x0F
-        self.flags.C = result <= 0xFF
+    @manager.add_instruction(0xDA)
+    def jc_addr(self) -> None:
+        address = self.fetch_word()
+        if self.flags.C:
+            self.PC = address
+        self.cycles += 10
 
-        self.registers[Registers.A] = result & 0xFF
-        self.cycles += 4
+    @manager.add_instruction(0xDB)
+    def in_d8(self) -> int:
+        port = self.fetch_byte()
+        if port == 0x01:
+            self.registers[Registers.A] = self.port_1
+        self.cycles += 10
 
-    @manager.add_instruction(0xF3)
-    def di(self):
-        self.interrupts_enabled = False
-        self.cycles += 4
+    @manager.add_instruction(0xDC)
+    def cc_addr(self):
+        address = self.fetch_word()
+        if self.flags.C:
+            h, l = split_word(self.PC)
+            self._push(h, l)
+            self.PC = address
+            self.cycles += 17
+            return
+        self.cycles += 11
 
-    @manager.add_instruction(0x17)
-    def ral_carry(self):
+    @manager.add_instruction(0xDE)
+    def sbi_d8(self) -> None:
         carry = 1 if self.flags.C else 0
+        i_value = self.fetch_byte()
+        i_value += carry
+        i_value &= 0xFF
+
         a_value = self.registers[Registers.A]
-        new_carry = a_value & 0x80
+        result = a_value - i_value
+        new_value = result & 0xFF
 
-        # Rotar el acumulador a la izquierda
-        # El bit de carry se convierte en el bit menos significativo (LSB)
-        a_value = (a_value << 1) | (carry >> 7)
+        self.registers[Registers.A] = new_value
+        self.set_flags(new_value)
+        self.set_carry_flag(result)
 
-        # Asegurarse de que el acumulador siga siendo de 8 bits
-        a_value = a_value & 0xFF
+        # twos complement
+        x = (i_value ^ 0xFF) + 0x01
 
-        self.registers[Registers.A] = a_value
-        self.flags.C = True if new_carry else False
+        c = ((x & 0xF) + (a_value & 0xF)) > 0xF
+        self.flags.A = c
+        self.cycles += 7
+
+    @manager.add_instruction(0xDF)
+    def rst_3(self) -> None:
+        if self.interrupts_enabled:
+            self.interrupts_enabled = False
+            h, l = split_word(self.PC)
+            self._push(h, l)
+            self.PC = 0x08 * 3
+            self.cycles += 11
+
+    @manager.add_instruction(0xE0)
+    def rpo(self) -> None:
+        if not self.flags.P:
+            h, l = self._pop()
+            self.PC = join_bytes(h, l)
+            self.cycles += 11
+            return
+        self.cycles += 5
+
+    @manager.add_instruction(0xE2)
+    def jpo_addr(self) -> None:
+        address = self.fetch_word()
+        if not self.flags.P:
+            self.PC = address
+            self.cycles += 17
+            return
+        self.cycles += 11
+
+    @manager.add_instruction(0xE3)
+    def xthl(self) -> None:
+        h, l = self.registers[Registers.H], self.registers[Registers.L]
+        self.registers[Registers.L] = self.read_memory_byte(self.SP)
+        self.registers[Registers.H] = self.read_memory_byte(self.SP + 0x01)
+        self.write_memory_word(self.SP, h, l)
+        self.cycles += 18
+
+    @manager.add_instruction(0xE4)
+    def cpo_addr(self) -> None:
+        address = self.fetch_word()
+        if not self.flags.P:
+            h, l = split_word(self.PC)
+            self._push(h, l)
+            self.PC = address
+            self.cycles += 17
+            return
+        self.cycles += 11
+
+    @manager.add_instruction(0xE6)
+    def ani_d8(self) -> None:
+        value1 = self.registers[Registers.A]
+        value2 = self.fetch_byte()
+
+        result = value1 & value2
+        self.registers[Registers.A] = result
+
+        self.set_flags(result)
+        self.flags.C = False
+        self.set_aux_carry_flag(value1, value2)
+        self.cycles += 7
+
+    @manager.add_instruction(0xE7)
+    def rst_4(self) -> None:
+        if self.interrupts_enabled:
+            self.interrupts_enabled = False
+            h, l = split_word(self.PC)
+            self._push(h, l)
+            self.PC = 0x20
+            self.cycles += 11
+
+    @manager.add_instruction(0xE8)
+    def rpe(self) -> None:
+        if self.flags.P:
+            h, l = self._pop()
+            self.PC = join_bytes(h, l)
+            self.cycles += 11
+            return
+        self.cycles += 5
+
+    @manager.add_instruction(0xE9)
+    def pchl(self) -> None:
+        h = self.registers[Registers.H]
+        l = self.registers[Registers.L]
+        self.PC = join_bytes(h, l)
+        self.cycles += 5
+
+    @manager.add_instruction(0xEA)
+    def jpe_addr(self) -> None:
+        address = self.fetch_word()
+        if self.flags.P:
+            self.PC = address
+            self.cycles += 10
+            return
+        self.cycles += 5
+
+    @manager.add_instruction(0xEB, [Registers.H, Registers.L, Registers.D, Registers.E])
+    def xchg(self, h: int, l: int, d: int, e: int) -> None:
+        """
+        The 16 bits of data held in the Hand L registers are exchanged
+        with the 16 bits of data held in the D and E registers.
+
+        Condition bits affected: None
+        """
+        h1 = self.registers[h]
+        l1 = self.registers[l]
+        d1 = self.registers[d]
+        e1 = self.registers[e]
+
+        self.registers[h] = d1
+        self.registers[l] = e1
+        self.registers[d] = h1
+        self.registers[e] = l1
+        self.cycles += 5
+
+    @manager.add_instruction(0xEC)
+    def cpe_addr(self) -> None:
+        address = self.fetch_word()
+        if self.flags.P:
+            h, l = split_word(self.PC)
+            self._push(h, l)
+            self.PC = address
+            self.cycles += 17
+            return
+
+        self.cycles += 11
 
     @manager.add_instruction(0xEE)
     def xri_d8(self):
@@ -1445,67 +1321,139 @@ class Intel8080(CPU):
         self.flags.P = (bin(result & 0xFF).count("1") % 2) == 0
         self.flags.A = False
         self.flags.C = False
+        self.cycles += 7
+
+    @manager.add_instruction(0xEF)
+    def rst_5(self) -> None:
+        if self.interrupts_enabled:
+            self.interrupts_enabled = False
+            h, l = split_word(self.PC)
+            self._push(h, l)
+            self.PC = 0x08 * 5
+            self.cycles += 11
+
+    @manager.add_instruction(0xF0)
+    def rp(self) -> None:
+        if self.flags.P:
+            h, l = self._pop()
+            self.PC = join_bytes(h, l)
+            self.cycles += 11
+            return
+        self.cycles += 5
+
+    @manager.add_instruction(0xF1)
+    def pop_psw(self) -> None:
+        self.registers[Registers.A], flags_byte = self._pop()
+        self.flags.set_flags(flags_byte)
+        self.cycles += 10
+
+    @manager.add_instruction(0xF2)
+    def jp_addr(self):
+        address = self.fetch_word()
+        if not self.flags.S:
+            self.PC = address
+        self.cycles += 10
+
+    @manager.add_instruction(0xF3)
+    def di(self):
+        self.interrupts_enabled = False
+        self.cycles += 4
+
+    @manager.add_instruction(0xF4)
+    def cp_addr(self) -> None:
+        address = self.fetch_word()
+        if not self.flags.S:
+            h, l = split_word(self.PC)
+            self._push(h, l)
+            self.PC = address
+            self.cycles += 17
+            return
+        self.cycles += 11
+
+    @manager.add_instruction(0xF5)
+    def push_psw(self) -> None:
+        self._push(self.registers[Registers.A], self.flags.get_flags())
+        self.cycles += 11
+
+    @manager.add_instruction(0xF6)
+    def ori_d8(self) -> None:
+        i_value = self.fetch_byte()
+        a_value = self.registers[Registers.A]
+        result = a_value | i_value
+        self.registers[Registers.A] = result
+
+        self.set_flags(result)
+        self.set_carry_flag(result)
+        self.set_aux_carry_flag(a_value, i_value)
 
         self.cycles += 7
 
-    @manager.add_instruction(0xE2)
-    def jpo(self) -> None:
-        address = self.fetch_word()
-        if not self.flags.P:
-            self.PC = address
-            self.cycles += 17
-            return
-
-        self.cycles += 11
-
-    @manager.add_instruction(0xE4)
-    def cpo_addr(self) -> None:
-        address = self.fetch_word()
-        if not self.flags.P:
+    @manager.add_instruction(0xF7)
+    def rst_6(self) -> None:
+        if self.interrupts_enabled:
+            self.interrupts_enabled = False
             h, l = split_word(self.PC)
-            self.push(h, l)
+            self._push(h, l)
+            self.PC = 0x30
+            self.cycles += 11
+
+    @manager.add_instruction(0xF8)
+    def rm(self) -> None:
+        if self.flags.S:
+            h, l = self._pop()
+            self.PC = join_bytes(h, l)
+            self.cycles += 11
+            return
+        self.cycles += 5
+
+    @manager.add_instruction(0xF9)
+    def sphl(self) -> None:
+        self.SP = join_bytes(self.registers[Registers.H], self.registers[Registers.L])
+        self.cycles += 5
+
+    @manager.add_instruction(0xFA)
+    def jm_addr(self) -> None:
+        address = self.fetch_word()
+        if self.flags.S:
+            self.PC = address
+
+        self.cycles += 10
+
+    @manager.add_instruction(0xFB)
+    def ei(self) -> None:
+        self.interrupts_enabled = True
+        self.cycles += 4
+
+    @manager.add_instruction(0xFC)
+    def cm_addr(self) -> None:
+        address = self.fetch_word()
+        if self.flags.S:
+            h, l = split_word(self.PC)
+            self._push(h, l)
             self.PC = address
             self.cycles += 17
             return
-
         self.cycles += 11
 
-    @manager.add_instruction(0xE8)
-    def rpe(self) -> None:
-        if self.flags.P:
-            h, l = self.pop()
-            self.PC = join_bytes(h, l)
+    @manager.add_instruction(0xFE, [Registers.A])
+    def cpi_d8(self, register: int) -> None:
+        """
+        The byte of immediate data is compared to the contents of the accumulator.
+        The comparison is performed by internally subtracting the data from the
+        accumulator using two's complement arithmetic, leaving the accumulator
+        unchanged but setting the condition bits by the result.
+
+        Since a subtract operation is performed, the Carry bit will be set if
+        there is no carry out of bit 7.
+        """
+        self.compare_with_twos_complement(self.registers[register], self.fetch_byte())
+        self.cycles += 7
+
+    @manager.add_instruction(0xFF)
+    def rst_7(self) -> None:
+        if not self.interrupts_enabled:
+            self.interrupts_enabled = False
+            h, l = split_word(self.PC)
+            self._push(h, l)
+            self.PC = 0x38
             self.cycles += 11
-            return
-
-        self.cycles += 5
-
-    @manager.add_instruction(0xE0)
-    def rpo(self) -> None:
-        if not self.flags.P:
-            h, l = self.pop()
-            self.PC = join_bytes(h, l)
-            self.cycles += 11
-            return
-
-        self.cycles += 5
-
-    @manager.add_instruction(0x8E)
-    def adc_m(self) -> None:
-        a_value = self.registers[Registers.A]
-
-        address = join_bytes(self.registers[Registers.H], self.registers[Registers.L])
-        value_2 = self.read_memory_byte(address)
-
-        value_2 += 1 if self.flags.C else 0
-        result = a_value + value_2
-
-        self.flags.S = (result & 0x80) != 0x00
-        self.flags.Z = (result & 0xFF) == 0x00
-        self.flags.P = (bin(result & 0xFF).count("1") % 2) == 0
-        self.flags.A = (get_ls_nib(a_value) + get_ls_nib(value_2)) > 0x0F
-        self.flags.C = result > 0xFF
-
-        self.registers[Registers.A] = result & 0xFF
-
-        self.cycles += 4


### PR DESCRIPTION
<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR re-orders opcodes in the Intel 8080 CPU implementation, updating method names to match the new opcode definitions and improving the overall structure of the code.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant CPU as Intel 8080 CPU
    participant Registers as CPU Registers
    participant Memory as Memory
    participant Flags as Flag Register
    participant SP as Stack Pointer

    Note over CPU: New Instructions Implementation
    
    CPU->>Registers: Register Operations (MOV, INR, DCR)
    CPU->>Memory: Memory Operations (LOAD, STORE)
    CPU->>Flags: Update Status Flags
    
    rect rgb(200, 200, 255)
        Note over CPU,SP: Stack Operations
        CPU->>SP: PUSH (Store registers to stack)
        CPU->>SP: POP (Restore registers from stack)
    end
    
    rect rgb(255, 200, 200)
        Note over CPU,Flags: Arithmetic & Logic
        CPU->>Registers: ADD, SUB, AND, OR, XOR
        CPU->>Flags: Update Carry, Zero, Sign flags
    end
    
    rect rgb(200, 255, 200)
        Note over CPU,Memory: Control Flow
        CPU->>Memory: JUMP instructions
        CPU->>Memory: CALL/RETURN instructions
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/JorgeJuarezM/xpire/pull/32/files#diff-858c63abde64d01be5792d751da8d8c5d0d4ec40ad2c24cfc4a2fc16303779c3>tests/test_intel_8080.py</a></td><td>Updated test cases to reflect new opcode method names.</td></tr>
<tr><td><a href=https://github.com/JorgeJuarezM/xpire/pull/32/files#diff-791bf21915b24ec4d37d2698d8e8ce62c5a233d88d3729a8aa63c051bee9e44c>xpire/cpus/intel_8080.py</a></td><td>Refactored opcode methods to improve clarity and maintainability.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->




