### PR TITLE
feat: add DAA Unit tests

### DIFF
--- a/tests/test_instructions/__init__.py
+++ b/tests/test_instructions/__init__.py
@@ -1,1 +1,0 @@
-from .test_daa import Test_DAA_Instruction

--- a/tests/test_instructions/__init__.py
+++ b/tests/test_instructions/__init__.py
@@ -1,0 +1,1 @@
+from .test_daa import Test_DAA_Instruction

--- a/tests/test_instructions/__init__.py
+++ b/tests/test_instructions/__init__.py
@@ -1,0 +1,5 @@
+from .test_daa import Test_DAA_Instruction
+
+__all__ = [
+    Test_DAA_Instruction,
+]

--- a/tests/test_instructions/test_daa.py
+++ b/tests/test_instructions/test_daa.py
@@ -1,0 +1,181 @@
+"""
+Test class for DAA Instruction.
+"""
+
+import unittest
+import unittest.mock
+
+from faker import Faker
+
+from xpire.cpus.intel_8080 import Intel8080
+
+
+fake = Faker()
+
+
+def bcd_encode(n):
+    l = (n % 10) & 0x0F
+    h = (n // 10) & 0x0F
+    return (h << 4) | l
+
+
+def bcd_decode(n):
+    l = n & 0x0F
+    h = (n >> 4) & 0x0F
+    return (h*10) + l
+
+class Test_DAA_Instruction(unittest.TestCase):
+    def setUp(self):
+        self.cpu = Intel8080()
+
+    def test_cycles(self):
+        self.cpu.write_memory_byte(0x0000, 0x27) # DAA
+        self.cpu.registers.A = 0x11
+        self.cpu.execute_instruction()
+        self.assertEqual(self.cpu.cycles, 4)
+
+    def test_1_plus_1(self):
+        self.cpu.write_memory_byte(0x0000, 0x80) # ADD 8
+        self.cpu.write_memory_byte(0x0001, 0x27) # DAA
+
+        self.cpu.registers.A = bcd_encode(1)
+        self.cpu.registers.B = bcd_encode(1)
+
+        self.cpu.execute_instruction()
+        self.cpu.execute_instruction()
+
+        self.assertEqual(bcd_decode(self.cpu.registers.A), 2)
+        self.assertFalse(self.cpu.flags.A)
+        self.assertFalse(self.cpu.flags.C)
+        self.assertEqual(self.cpu.PC, 2)
+
+    def test_9_plus_1(self):
+        self.cpu.write_memory_byte(0x0000, 0x80) # ADD 8
+        self.cpu.write_memory_byte(0x0001, 0x27) # DAA
+
+        self.cpu.registers.A = bcd_encode(9)
+        self.cpu.registers.B = bcd_encode(1)
+
+        self.cpu.execute_instruction()
+        self.cpu.execute_instruction()
+
+        self.assertEqual(bcd_decode(self.cpu.registers.A), 10)
+        self.assertTrue(self.cpu.flags.A)
+        self.assertFalse(self.cpu.flags.C)
+        self.assertEqual(self.cpu.PC, 2)
+
+    def test_9_plus_10(self):
+        self.cpu.write_memory_byte(0x0000, 0x80) # ADD 8
+        self.cpu.write_memory_byte(0x0001, 0x27) # DAA
+
+        self.cpu.registers.A = bcd_encode(9)
+        self.cpu.registers.B = bcd_encode(10)
+
+        self.cpu.execute_instruction()
+        self.cpu.execute_instruction()
+
+        self.assertEqual(bcd_decode(self.cpu.registers.A), 19)
+        self.assertFalse(self.cpu.flags.A)
+        self.assertFalse(self.cpu.flags.C)
+        self.assertEqual(self.cpu.PC, 2)
+
+    def test_22_plus_39(self):
+        self.cpu.write_memory_byte(0x0000, 0x80) # ADD 8
+        self.cpu.write_memory_byte(0x0001, 0x27) # DAA
+
+        self.cpu.registers.A = bcd_encode(22)
+        self.cpu.registers.B = bcd_encode(39)
+
+        self.cpu.execute_instruction()
+        self.cpu.execute_instruction()
+
+        self.assertEqual(bcd_decode(self.cpu.registers.A), 61)
+        self.assertTrue(self.cpu.flags.A)
+        self.assertFalse(self.cpu.flags.C)
+        self.assertEqual(self.cpu.PC, 2)
+
+    def test_95_plus_20(self):
+        self.cpu.write_memory_byte(0x0000, 0x80) # ADD 8
+        self.cpu.write_memory_byte(0x0001, 0x27) # DAA
+
+        self.cpu.registers.A = bcd_encode(95)
+        self.cpu.registers.B = bcd_encode(20)
+
+        self.cpu.execute_instruction()
+        self.cpu.execute_instruction()
+
+        self.assertEqual(bcd_decode(self.cpu.registers.A), 15)
+        self.assertFalse(self.cpu.flags.A)
+        self.assertTrue(self.cpu.flags.C)
+        self.assertEqual(self.cpu.PC, 2)
+
+    def test_daa_0x3f(self):
+        self.cpu.write_memory_byte(0x0000, 0x27) # DAA
+        self.cpu.registers.A = 0x3F
+
+        self.cpu.execute_instruction()
+
+        self.assertEqual(self.cpu.registers.A, 0x45)
+        self.assertTrue(self.cpu.flags.A)
+        self.assertFalse(self.cpu.flags.C)
+        self.assertEqual(self.cpu.PC, 1)
+
+    def test_daa_0xfa(self):
+        self.cpu.write_memory_byte(0x0000, 0x27)
+        self.cpu.registers.A = 0xFA 
+
+        self.cpu.execute_instruction()
+
+        self.assertEqual(self.cpu.registers.A, 0x60)
+        self.assertTrue(self.cpu.flags.A)
+        self.assertTrue(self.cpu.flags.C)
+        self.assertEqual(self.cpu.PC, 1)
+
+    def test_daa_0x11(self):
+        self.cpu.write_memory_byte(0x0000, 0x27)
+        self.cpu.registers.A = 0x11
+        self.cpu.flags.C = True
+
+        self.cpu.execute_instruction()
+
+        self.assertEqual(self.cpu.registers.A, 0x71)
+        self.assertFalse(self.cpu.flags.A)
+        self.assertFalse(self.cpu.flags.C)
+        self.assertEqual(self.cpu.PC, 1)
+
+
+    def test_daa_20_minus_3(self):
+        #   1
+        self.cpu.flags.C = True
+
+        #  2
+        self.cpu.registers.A = 0x99
+        self.cpu.registers.B = 0x00
+
+        #  3
+        self.cpu.write_memory_byte(0x0000, 0x88) # ADC B
+        self.cpu.execute_instruction()
+
+        self.assertEqual(self.cpu.registers.A, 0x9A)
+        self.assertFalse(self.cpu.flags.C)
+
+        #  4
+        self.cpu.registers.B = 3
+        self.cpu.write_memory_byte(0x0001, 0x90) # SUB B
+        self.cpu.execute_instruction()
+
+        self.assertEqual(bcd_decode(self.cpu.registers.A), 97)
+
+        #  5
+        self.cpu.registers.B = bcd_encode(20)
+        self.cpu.write_memory_byte(0x0002, 0x80) # ADD B
+        self.cpu.execute_instruction()
+
+        self.assertEqual(bcd_decode(self.cpu.registers.A), 117)
+
+        #  6
+        self.cpu.write_memory_byte(0x0003, 0x27)
+        self.cpu.execute_instruction()
+
+        self.assertEqual(bcd_decode(self.cpu.registers.A), 17)
+        self.assertTrue(self.cpu.flags.C)

--- a/tests/test_instructions/test_daa.py
+++ b/tests/test_instructions/test_daa.py
@@ -6,13 +6,8 @@ Thanks to GunshipPenguin for the test cases.
 """
 
 import unittest
-import unittest.mock
-
-from faker import Faker
 
 from xpire.cpus.intel_8080 import Intel8080
-
-fake = Faker()
 
 
 def bcd_encode(n):

--- a/tests/test_instructions/test_daa.py
+++ b/tests/test_instructions/test_daa.py
@@ -9,7 +9,6 @@ from faker import Faker
 
 from xpire.cpus.intel_8080 import Intel8080
 
-
 fake = Faker()
 
 
@@ -22,21 +21,22 @@ def bcd_encode(n):
 def bcd_decode(n):
     l = n & 0x0F
     h = (n >> 4) & 0x0F
-    return (h*10) + l
+    return (h * 10) + l
+
 
 class Test_DAA_Instruction(unittest.TestCase):
     def setUp(self):
         self.cpu = Intel8080()
 
     def test_cycles(self):
-        self.cpu.write_memory_byte(0x0000, 0x27) # DAA
+        self.cpu.write_memory_byte(0x0000, 0x27)  # DAA
         self.cpu.registers.A = 0x11
         self.cpu.execute_instruction()
         self.assertEqual(self.cpu.cycles, 4)
 
     def test_1_plus_1(self):
-        self.cpu.write_memory_byte(0x0000, 0x80) # ADD 8
-        self.cpu.write_memory_byte(0x0001, 0x27) # DAA
+        self.cpu.write_memory_byte(0x0000, 0x80)  # ADD 8
+        self.cpu.write_memory_byte(0x0001, 0x27)  # DAA
 
         self.cpu.registers.A = bcd_encode(1)
         self.cpu.registers.B = bcd_encode(1)
@@ -50,8 +50,8 @@ class Test_DAA_Instruction(unittest.TestCase):
         self.assertEqual(self.cpu.PC, 2)
 
     def test_9_plus_1(self):
-        self.cpu.write_memory_byte(0x0000, 0x80) # ADD 8
-        self.cpu.write_memory_byte(0x0001, 0x27) # DAA
+        self.cpu.write_memory_byte(0x0000, 0x80)  # ADD 8
+        self.cpu.write_memory_byte(0x0001, 0x27)  # DAA
 
         self.cpu.registers.A = bcd_encode(9)
         self.cpu.registers.B = bcd_encode(1)
@@ -65,8 +65,8 @@ class Test_DAA_Instruction(unittest.TestCase):
         self.assertEqual(self.cpu.PC, 2)
 
     def test_9_plus_10(self):
-        self.cpu.write_memory_byte(0x0000, 0x80) # ADD 8
-        self.cpu.write_memory_byte(0x0001, 0x27) # DAA
+        self.cpu.write_memory_byte(0x0000, 0x80)  # ADD 8
+        self.cpu.write_memory_byte(0x0001, 0x27)  # DAA
 
         self.cpu.registers.A = bcd_encode(9)
         self.cpu.registers.B = bcd_encode(10)
@@ -80,8 +80,8 @@ class Test_DAA_Instruction(unittest.TestCase):
         self.assertEqual(self.cpu.PC, 2)
 
     def test_22_plus_39(self):
-        self.cpu.write_memory_byte(0x0000, 0x80) # ADD 8
-        self.cpu.write_memory_byte(0x0001, 0x27) # DAA
+        self.cpu.write_memory_byte(0x0000, 0x80)  # ADD 8
+        self.cpu.write_memory_byte(0x0001, 0x27)  # DAA
 
         self.cpu.registers.A = bcd_encode(22)
         self.cpu.registers.B = bcd_encode(39)
@@ -95,8 +95,8 @@ class Test_DAA_Instruction(unittest.TestCase):
         self.assertEqual(self.cpu.PC, 2)
 
     def test_95_plus_20(self):
-        self.cpu.write_memory_byte(0x0000, 0x80) # ADD 8
-        self.cpu.write_memory_byte(0x0001, 0x27) # DAA
+        self.cpu.write_memory_byte(0x0000, 0x80)  # ADD 8
+        self.cpu.write_memory_byte(0x0001, 0x27)  # DAA
 
         self.cpu.registers.A = bcd_encode(95)
         self.cpu.registers.B = bcd_encode(20)
@@ -110,7 +110,7 @@ class Test_DAA_Instruction(unittest.TestCase):
         self.assertEqual(self.cpu.PC, 2)
 
     def test_daa_0x3f(self):
-        self.cpu.write_memory_byte(0x0000, 0x27) # DAA
+        self.cpu.write_memory_byte(0x0000, 0x27)  # DAA
         self.cpu.registers.A = 0x3F
 
         self.cpu.execute_instruction()
@@ -122,7 +122,7 @@ class Test_DAA_Instruction(unittest.TestCase):
 
     def test_daa_0xfa(self):
         self.cpu.write_memory_byte(0x0000, 0x27)
-        self.cpu.registers.A = 0xFA 
+        self.cpu.registers.A = 0xFA
 
         self.cpu.execute_instruction()
 
@@ -143,8 +143,24 @@ class Test_DAA_Instruction(unittest.TestCase):
         self.assertFalse(self.cpu.flags.C)
         self.assertEqual(self.cpu.PC, 1)
 
-
     def test_daa_20_minus_3(self):
+        """
+        /*
+        * Steps in decimal subtraction on the 8080
+        *
+        * 1) Set the carry bit to 1 indicating no borrow
+        * 2) Load the accumulator with 0x99 representing 99 in decimal
+        * 3) Add 0 to the accumulator with carry producing either 0x99 or 0x9A and
+        *    resetting the carry bit
+        * 4) Subtract the subtrahend digits from the accumulator producing either 99's
+        *    or 100's complement
+        * 5) Add the minuend digits to the accumulator
+        * 6) Use DAA to make sure the result in the accumulator is in decimal format
+        *    and to indicate a borrow in the carry bit if one occurred
+        * 7) If there are more digits to subtract, got to step 2, otherwise, stop
+        */
+        """
+
         #   1
         self.cpu.flags.C = True
 
@@ -153,7 +169,7 @@ class Test_DAA_Instruction(unittest.TestCase):
         self.cpu.registers.B = 0x00
 
         #  3
-        self.cpu.write_memory_byte(0x0000, 0x88) # ADC B
+        self.cpu.write_memory_byte(0x0000, 0x88)  # ADC B
         self.cpu.execute_instruction()
 
         self.assertEqual(self.cpu.registers.A, 0x9A)
@@ -161,14 +177,14 @@ class Test_DAA_Instruction(unittest.TestCase):
 
         #  4
         self.cpu.registers.B = 3
-        self.cpu.write_memory_byte(0x0001, 0x90) # SUB B
+        self.cpu.write_memory_byte(0x0001, 0x90)  # SUB B
         self.cpu.execute_instruction()
 
         self.assertEqual(bcd_decode(self.cpu.registers.A), 97)
 
         #  5
         self.cpu.registers.B = bcd_encode(20)
-        self.cpu.write_memory_byte(0x0002, 0x80) # ADD B
+        self.cpu.write_memory_byte(0x0002, 0x80)  # ADD B
         self.cpu.execute_instruction()
 
         self.assertEqual(bcd_decode(self.cpu.registers.A), 117)

--- a/tests/test_instructions/test_daa.py
+++ b/tests/test_instructions/test_daa.py
@@ -1,5 +1,8 @@
 """
 Test class for DAA Instruction.
+
+Thanks to GunshipPenguin for the test cases.
+    https://github.com/GunshipPenguin/lib8080/blob/master/test/unit/instructions/daa_test.c
 """
 
 import unittest

--- a/xpire/cpus/intel_8080.py
+++ b/xpire/cpus/intel_8080.py
@@ -362,12 +362,12 @@ class Intel8080(CPU):
 
         lsb = self.registers.A & 0x0F
         if half_carry or lsb > 9:
-            accumulator = accumulator + 0x06
+            accumulator = (accumulator + 0x06) & 0xFF
             self.flags.A = (lsb + 0x06) > 0xF
 
         msb = self.registers.A >> 4
         if carry or msb > 9:
-            accumulator = accumulator + 0x60
+            accumulator = (accumulator + 0x60) & 0xFF
             self.flags.C = (msb + 0x06) > 0x0F
         else:
             self.flags.C = False

--- a/xpire/cpus/intel_8080.py
+++ b/xpire/cpus/intel_8080.py
@@ -360,14 +360,14 @@ class Intel8080(CPU):
         carry = 1 if self.flags.C else 0
         half_carry = 1 if self.flags.A else 0
 
-        lsb = accumulator & 0x0F
+        lsb = self.registers.A & 0x0F
         if half_carry or lsb > 9:
-            accumulator = (accumulator + 0x06) & 0xFF
+            accumulator = accumulator + 0x06
             self.flags.A = (lsb + 0x06) > 0xF
 
-        msb = accumulator >> 4
+        msb = self.registers.A >> 4
         if carry or msb > 9:
-            accumulator = (accumulator + 0x60) & 0xFF
+            accumulator = accumulator + 0x60
             self.flags.C = (msb + 0x06) > 0x0F
         else:
             self.flags.C = False
@@ -376,6 +376,7 @@ class Intel8080(CPU):
         self.flags.Z = (accumulator & 0xFF) == 0x00
         self.flags.S = (accumulator & 0x80) != 0x00
         self.flags.P = (bin(accumulator & 0xFF).count("1") % 2) == 0
+        self.cycles += 4
 
     @manager.add_instruction(0x2A)
     def lhld(self) -> None:


### PR DESCRIPTION
<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds unit tests for the DAA instruction in the Intel 8080 CPU emulator, ensuring the correctness of the instruction's behavior with various input scenarios.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant Test as Test_DAA_Instruction
    participant CPU as Intel8080
    participant BCD as BCD Functions

    Test->>CPU: Initialize CPU
    Note over Test,CPU: Setup test environment

    rect rgb(200, 220, 255)
        Test->>BCD: bcd_encode(decimal_number)
        BCD-->>Test: Returns BCD encoded value
        Test->>CPU: Write test instructions to memory
        Test->>CPU: Set register A and flags
        Test->>CPU: execute_instruction()
        CPU->>CPU: Process DAA instruction
        Note over CPU: 1. Check lower nibble (0-9)<br>2. Check upper nibble (0-9)<br>3. Adjust BCD result<br>4. Set flags (C,A,Z,S,P)<br>5. Add 4 cycles
        CPU-->>Test: Return control
        Test->>BCD: bcd_decode(result)
        BCD-->>Test: Returns decimal value
        Test->>Test: Assert expected results
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/JorgeJuarezM/xpire/pull/36/files#diff-d441e63a7e773784725334f38379f289e6a14957985decbb343092b7c83b7ca2>tests/test_instructions/__init__.py</a></td><td>Added an import for the Test_DAA_Instruction class.</td></tr>
<tr><td><a href=https://github.com/JorgeJuarezM/xpire/pull/36/files#diff-6bb25607edb41b486401b73011ece2c9d2305f6e26f9f83bc6b0377b246ceb31>tests/test_instructions/test_daa.py</a></td><td>Implemented unit tests for the DAA instruction, covering various cases.</td></tr>
<tr><td><a href=https://github.com/JorgeJuarezM/xpire/pull/36/files#diff-791bf21915b24ec4d37d2698d8e8ce62c5a233d88d3729a8aa63c051bee9e44c>xpire/cpus/intel_8080.py</a></td><td>Modified the DAA method to use the accumulator directly from the registers.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->






