### PR TITLE
[FEAT] Add unit tests for INR-reg Instructions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Run tests
         run: |
-          coverage run -m unittest discover -s tests -p 'test_*.py'
+          coverage run -m unittest tests -v
 
       - name: Generate coverage report
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	python -m unittest tests
+	python -m unittest tests -v
 
 test_asm:
 	asm80 examples/tests.asm -o examples/tests.bin

--- a/tests/test_devices/test_device.py
+++ b/tests/test_devices/test_device.py
@@ -12,7 +12,7 @@ from xpire.devices.device import Device, P1Controls, Shifter
 fake = Faker()
 
 
-class TestSpaceInvadersScene(unittest.TestCase):
+class TestDevice(unittest.TestCase):
     def setUp(self):
         self.device = Device()
 

--- a/tests/test_instructions/__init__.py
+++ b/tests/test_instructions/__init__.py
@@ -1,2 +1,3 @@
 from .test_add import *  # noqa
 from .test_daa import *  # noqa
+from .test_inr import *  # noqa

--- a/tests/test_instructions/test_inr.py
+++ b/tests/test_instructions/test_inr.py
@@ -1,0 +1,105 @@
+"""
+Test class for INR Instruction.
+
+Thanks to chris-j-akers for the test cases.
+    https://github.com/chris-j-akers/i8080-javascript/blob/main/src/unit_tests/arithmetic/inr.reg.test.js
+"""
+
+from tests.base.intel_8080 import Intel8080_Base
+
+reg_map = {
+    "B": 0x04,
+    "C": 0x0C,
+    "D": 0x14,
+    "E": 0x1C,
+    "H": 0x24,
+    "L": 0x2C,
+    "A": 0x3C,
+}
+
+
+class Test_INR_Instruction(Intel8080_Base):
+
+    def test_set_no_flags(self):
+        for reg, opcode in reg_map.items():
+            self.cpu.registers[reg] = 0x00
+            self.cpu.write_memory_byte(0x0000, opcode)  # INR reg
+
+            current_carry = self.cpu.flags.C
+            self.cpu.execute_instruction()
+
+            self.assertEqual(
+                self.cpu.registers[reg],
+                0x01,
+                f"Expected {reg} to be incremented to 0x01",
+            )
+            self.assertEqual(self.cpu.flags.C, current_carry)  # No change
+            self.assertFalse(self.cpu.flags.P)
+            self.assertFalse(self.cpu.flags.A)
+            self.assertFalse(self.cpu.flags.Z)
+            self.assertFalse(self.cpu.flags.S)
+            self.assertEqual(self.cpu.cycles, 5)
+            self.cpu.reset()
+
+    def test_rollover_from_0xff(self):
+        for reg, opcode in reg_map.items():
+            self.cpu.registers[reg] = 0xFF
+            self.cpu.write_memory_byte(0x0000, opcode)
+
+            current_carry = self.cpu.flags.C
+            self.cpu.execute_instruction()
+
+            self.assertEqual(
+                self.cpu.registers[reg],
+                0x00,
+                f"Expected {reg} to rollover to 0x00 after incrementing from 0xFF",
+            )
+            self.assertEqual(self.cpu.flags.C, current_carry)
+            self.assertTrue(self.cpu.flags.P)
+            self.assertTrue(self.cpu.flags.A)
+            self.assertTrue(self.cpu.flags.Z)
+            self.assertFalse(self.cpu.flags.S)
+            self.assertEqual(self.cpu.cycles, 5)
+            self.cpu.reset()
+
+    def test_set_parity_flag(self):
+        for reg, opcode in reg_map.items():
+            self.cpu.registers[reg] = 0x54  # 84 dec
+            self.cpu.write_memory_byte(0x0000, opcode)
+
+            current_carry = self.cpu.flags.C
+            self.cpu.execute_instruction()
+
+            self.assertEqual(
+                self.cpu.registers[reg],
+                0x55,  # 85 dec
+                f"Expected {reg} to be incremented to 0x55",
+            )
+            self.assertEqual(self.cpu.flags.C, current_carry)
+            self.assertTrue(self.cpu.flags.P)
+            self.assertFalse(self.cpu.flags.A)
+            self.assertFalse(self.cpu.flags.Z)
+            self.assertFalse(self.cpu.flags.S)
+            self.assertEqual(self.cpu.cycles, 5)
+            self.cpu.reset()
+
+    def test_set_sign_flag(self):
+        for reg, opcode in reg_map.items():
+            self.cpu.registers[reg] = 0xAF  # 175 dec
+            self.cpu.write_memory_byte(0x0000, opcode)
+
+            current_carry = self.cpu.flags.C
+            self.cpu.execute_instruction()
+
+            self.assertEqual(
+                self.cpu.registers[reg],
+                0xB0,  # 176 dec
+                f"Expected {reg} to be incremented to 0xb0",
+            )
+            self.assertEqual(self.cpu.flags.C, current_carry)
+            self.assertFalse(self.cpu.flags.P)
+            self.assertTrue(self.cpu.flags.A)
+            self.assertFalse(self.cpu.flags.Z)
+            self.assertTrue(self.cpu.flags.S)
+            self.assertEqual(self.cpu.cycles, 5)
+            self.cpu.reset()

--- a/xpire/cpus/cpu.py
+++ b/xpire/cpus/cpu.py
@@ -47,9 +47,11 @@ class CPU(AbstractCPU):
 
         The CPU object starts a new thread to execute instructions.
         """
+        self.reset()
+
+    def reset(self):
         self.memory = bytearray(0x10000)
         self.registers = Registers()
-        self.flags = {}
 
         self.SP = 0x0000
         self.PC = 0x0000


### PR DESCRIPTION
- **feat: add (ADD) instruction tests**
- **chore: format**
- **fix: tests**
- **chore: docstring**
- **fix: merge tests**
- **chore: rename test screen**
- **feat: add unit tests for INR**


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds unit tests for the INR instruction, modifies test execution commands, and makes some formatting changes.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant Test as Test Runner
    participant CPU as CPU Class
    participant INR as INR Instruction
    participant Registers as CPU Registers

    Test->>CPU: Initialize CPU
    CPU->>CPU: reset()
    CPU->>Registers: Initialize registers

    rect rgb(200, 200, 255)
        Note over Test,Registers: INR (Increment Register) Tests
        Test->>CPU: Write INR opcode to memory
        Test->>CPU: execute_instruction()
        CPU->>INR: Process INR instruction
        INR->>Registers: Increment register value
        INR->>Registers: Update flags (P,A,Z,S)
        INR-->>Test: Return control
        Test->>CPU: Verify register values and flags
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/JorgeJuarezM/xpire/pull/40/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52>Makefile</a></td><td>Updated the test command to include verbose output.</td></tr>
<tr><td><a href=https://github.com/JorgeJuarezM/xpire/pull/40/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88>.github/workflows/test.yml</a></td><td>Modified the test command to run with verbose output.</td></tr>
<tr><td><a href=https://github.com/JorgeJuarezM/xpire/pull/40/files#diff-821f7e3c7c67461cfaef1f709dcdbf04f4738d8944ffc343e1db704184afedcf>tests/test_instructions/test_inr.py</a></td><td>Added a new test class for INR instruction with multiple test cases.</td></tr>
<tr><td><a href=https://github.com/JorgeJuarezM/xpire/pull/40/files#diff-95d2166746dba492d6b5bdd26fa05730623039d96f0e0a197f8446d25bc66b6a>tests/test_devices/test_device.py</a></td><td>Renamed the test class for clarity.</td></tr>
<tr><td><a href=https://github.com/JorgeJuarezM/xpire/pull/40/files#diff-d441e63a7e773784725334f38379f289e6a14957985decbb343092b7c83b7ca2>tests/test_instructions/__init__.py</a></td><td>Included the new INR test module.</td></tr>
<tr><td><a href=https://github.com/JorgeJuarezM/xpire/pull/40/files#diff-72dcbc6a396c9ef564cfc4e41663c437f4c56106930914f124e27e973d824c1e>xpire/cpus/cpu.py</a></td><td>Added a reset method to initialize CPU state.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.yml`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->






